### PR TITLE
Add handling for wrong argument format

### DIFF
--- a/src/Microsoft.AspNet.ConfigurationModel/Sources/CommandLineConfigurationSource.cs
+++ b/src/Microsoft.AspNet.ConfigurationModel/Sources/CommandLineConfigurationSource.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNet.ConfigurationModel.Sources
                 if (split <= 0)
                 {
                     // TODO: exception message localization
-                    throw new FormatException(string.Format("Unrecognized argument '{0}.'", pair));
+                    throw new FormatException(string.Format("Unrecognized argument '{0}'.", pair));
                 }
 
                 string key = pair.Substring(0, split);


### PR DESCRIPTION
I found
`#warning TODO - this is a placeholder algorithm which must be replaced`
at line 25 in `CommandLineConfigurationSource` class. So I improved the robustness of the algorithm by adding wrong format handling.

@loudej  What else should I do if I want to remove the `#warning`? The current cmd argument parser can only handle the following format:

```
Program.exe arg1=val1 arg2="val2"
```

<!---
@huboard:{"order":5.25,"custom_state":"ready"}
-->
