### PR TITLE
Remove preprocessing for APPSETTING prefix in Azure environment variables

### DIFF
--- a/src/Microsoft.AspNet.ConfigurationModel/Sources/EnvironmentVariablesConfigurationSource.cs
+++ b/src/Microsoft.AspNet.ConfigurationModel/Sources/EnvironmentVariablesConfigurationSource.cs
@@ -11,7 +11,6 @@ namespace Microsoft.AspNet.ConfigurationModel.Sources
         private const string SqlAzureServerPrefix = "SQLAZURECONNSTR_";
         private const string SqlServerPrefix = "SQLCONNSTR_";
         private const string CustomPrefix = "CUSTOMCONNSTR_";
-        private const string AppSettingPrefix = "APPSETTING_";
 
         private const string ConnStrKeyFormat = "Data:{0}:ConnectionString";
         private const string ProviderKeyFormat = "Data:{0}:ProviderName";
@@ -69,11 +68,6 @@ namespace Microsoft.AspNet.ConfigurationModel.Sources
             else if (key.StartsWith(CustomPrefix, StringComparison.OrdinalIgnoreCase))
             {
                 prefix = CustomPrefix;
-            }
-            else if (key.StartsWith(AppSettingPrefix, StringComparison.OrdinalIgnoreCase))
-            {
-                yield return new DictionaryEntry(key.Substring(AppSettingPrefix.Length), entry.Value);
-                yield break;
             }
             else
             {

--- a/test/Microsoft.AspNet.ConfigurationModel.Test/EnvironmentVariablesConfigurationSourceTest.cs
+++ b/test/Microsoft.AspNet.ConfigurationModel.Test/EnvironmentVariablesConfigurationSourceTest.cs
@@ -63,7 +63,8 @@ namespace Microsoft.AspNet.ConfigurationModel.Sources
             envConfigSrc.Load(dic);
 
             Assert.Equal(9, envConfigSrc.Data.Count);
-            Assert.Equal("TestAppName", envConfigSrc.Data["AppName"]);
+            Assert.Equal("TestAppName", envConfigSrc.Data["APPSETTING_AppName"]);
+            Assert.False(envConfigSrc.Data.ContainsKey("AppName"));
             Assert.Equal("CustomConnStr", envConfigSrc.Data["Data:db1:ConnectionString"]);
             Assert.Equal("SQLConnStr", envConfigSrc.Data["Data:db2:ConnectionString"]);
             Assert.Equal("System.Data.SqlClient", envConfigSrc.Data["Data:db2:ProviderName"]);
@@ -79,7 +80,6 @@ namespace Microsoft.AspNet.ConfigurationModel.Sources
         {
             var dic = new Hashtable()
                 {
-                    {"APPSETTING_AppName", "TestAppName"},
                     {"CUSTOMCONNSTR_db1", "CustomConnStr"},
                     {"SQLCONNSTR_db2", "SQLConnStr"},
                     {"MYSQLCONNSTR_db3", "MySQLConnStr"},


### PR DESCRIPTION
Fix bug #38 

We don't need to strip the `APPSETTING_` prefix off since Azure has
already done it for users.

For each key-value pair (e.g. `UserKey = UserValue`) user specifies in "app settings" section on Azure portal, Azure generates two environment variables (e.g. `UserKey = UserValue` and `APPSETTING_UserKey = UserValue`).

<!---
@huboard:{"order":6.65625,"custom_state":"ready"}
-->
