### PR TITLE
Declare NeutralResourcesLanguage

### DIFF
--- a/src/Microsoft.AspNet.ConfigurationModel/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.AspNet.ConfigurationModel/Properties/AssemblyInfo.cs
@@ -52,3 +52,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
 [assembly: InternalsVisibleTo("Microsoft.AspNet.ConfigurationModel.Test")]
+[assembly: NeutralResourcesLanguage("en-US")]


### PR DESCRIPTION
Without this, Uinversal apps can't load resources properly.
