### PR TITLE
Remove unit tests related to Hashtable when using KCore

### DIFF
--- a/test/Microsoft.AspNet.ConfigurationModel.Test/EnvironmentVariablesConfigurationSourceTest.cs
+++ b/test/Microsoft.AspNet.ConfigurationModel.Test/EnvironmentVariablesConfigurationSourceTest.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if NET45
+using System;
 using System.Collections;
 using Xunit;
 
@@ -128,3 +129,4 @@ namespace Microsoft.AspNet.ConfigurationModel.Sources
         }
     }
 }
+#endif


### PR DESCRIPTION
`Hashtable` was used to fake the result returned by `Environment.GetEnvironmentVariables()`. However, `Hashtable` doesn't exist in KCore.
