### PR TITLE
Adding switch to build.cmd to skip KRE install

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -18,6 +18,8 @@ copy %CACHED_NUGET% .nuget\nuget.exe > nul
 IF EXIST packages\KoreBuild goto run
 .nuget\NuGet.exe install KoreBuild -ExcludeVersion -o packages -nocache -pre
 .nuget\NuGet.exe install Sake -version 0.2 -o packages -ExcludeVersion
+
+IF %SKIP_KRE_INSTALL% goto run
 CALL packages\KoreBuild\build\kvm upgrade -svr50 -x86
 CALL packages\KoreBuild\build\kvm install default -svrc50 -x86
 


### PR DESCRIPTION
@loudej The idea would be to run install from the volatile feed and set this switch prior to invoking build.cmd.

cc @davidfowl 
