### PR TITLE
Make duplicate key override instead of throwing exception in CommandLineConfigurationSource

### DIFF
--- a/src/Microsoft.Framework.ConfigurationModel/Sources/CommandLineConfigurationSource.cs
+++ b/src/Microsoft.Framework.ConfigurationModel/Sources/CommandLineConfigurationSource.cs
@@ -123,11 +123,7 @@ namespace Microsoft.Framework.ConfigurationModel
                     value = currentArg.Substring(separator + 1);
                 }
 
-                if (data.ContainsKey(key))
-                {
-                    throw new FormatException(Resources.FormatError_KeyIsDuplicated(key));
-                }
-
+                // Override value when key is duplicated. So we always have the last argument win.
                 data[key] = value;
                 argIndex++;
             }

--- a/test/Microsoft.Framework.ConfigurationModel.Test/CommandLineConfigurationSourceTest.cs
+++ b/test/Microsoft.Framework.ConfigurationModel.Test/CommandLineConfigurationSourceTest.cs
@@ -147,19 +147,19 @@ namespace Microsoft.Framework.ConfigurationModel
         }
 
         [Fact]
-        public void ThrowExceptionWhenKeyIsDuplicated()
+        public void OverrideValueWhenKeyIsDuplicated()
         {
             var args = new string[]
                 {
                     "/Key1=Value1",
                     "--Key1=Value2"
                 };
-            var expectedMsg = new FormatException(Resources.FormatError_KeyIsDuplicated("Key1")).Message;
             var cmdLineConfig = new CommandLineConfigurationSource(args);
 
-            var exception = Assert.Throws<FormatException>(() => cmdLineConfig.Load());
+            cmdLineConfig.Load();
 
-            Assert.Equal(expectedMsg, exception.Message);
+            Assert.Equal(1, cmdLineConfig.Data.Count());
+            Assert.Equal("Value2", cmdLineConfig.Data["Key1"]);
         }
 
         [Fact]


### PR DESCRIPTION
parent #81 
