### PR TITLE
Sharing the PCL Love - enable win81 and wpa81 in shared package

### DIFF
--- a/src/Microsoft.Framework.ConfigurationModel.Shared/project.json
+++ b/src/Microsoft.Framework.ConfigurationModel.Shared/project.json
@@ -8,6 +8,11 @@
             "dependencies": { 
                 "System.Runtime": "4.0.20.0"
             }
+        },
+        ".NETPortable,Version=v4.6,Profile=Profile151": {
+            "dependencies": { 
+                "System.Runtime": ""
+            }
         }
     }
 }


### PR DESCRIPTION
Microsoft.Framework.ConfigurationModel supports these platforms but it's not useable because it depends on Microsoft.Framework.ConfigurationModel.Shared which did not support them... fixing that.
