### PR TITLE
Fixing the JSON config source to handle keys with '.'

### DIFF
--- a/test/Microsoft.Framework.ConfigurationModel.FunctionalTests/ConfigurationTests.cs
+++ b/test/Microsoft.Framework.ConfigurationModel.FunctionalTests/ConfigurationTests.cs
@@ -42,9 +42,9 @@ CommonKey3:CommonKey4=IniValue6";
         private static readonly string _jsonConfigFileContent =
             @"{
   ""JsonKey1"": ""JsonValue1"",
-  ""JsonKey2"": {
+  ""Json.Key2"": {
     ""JsonKey3"": ""JsonValue2"",
-    ""JsonKey4"": ""JsonValue3"",
+    ""Json.Key4"": ""JsonValue3"",
     ""JsonKey5:JsonKey6"": ""JsonValue4""
   },
   ""CommonKey1"": {
@@ -98,9 +98,9 @@ CommonKey3:CommonKey4=IniValue6";
             Assert.Equal("IniValue5", config.Get("CommonKey1:CommonKey2:IniKey7"));
 
             Assert.Equal("JsonValue1", config.Get("JsonKey1"));
-            Assert.Equal("JsonValue2", config.Get("JsonKey2:JsonKey3"));
-            Assert.Equal("JsonValue3", config.Get("JsonKey2:JsonKey4"));
-            Assert.Equal("JsonValue4", config.Get("JsonKey2:JsonKey5:JsonKey6"));
+            Assert.Equal("JsonValue2", config.Get("Json.Key2:JsonKey3"));
+            Assert.Equal("JsonValue3", config.Get("Json.Key2:Json.Key4"));
+            Assert.Equal("JsonValue4", config.Get("Json.Key2:JsonKey5:JsonKey6"));
             Assert.Equal("JsonValue5", config.Get("CommonKey1:CommonKey2:JsonKey7"));
 
             Assert.Equal("XmlValue1", config.Get("XmlKey1"));

--- a/test/Microsoft.Framework.ConfigurationModel.Json.Test/JsonConfigurationSourceTest.cs
+++ b/test/Microsoft.Framework.ConfigurationModel.Json.Test/JsonConfigurationSourceTest.cs
@@ -18,20 +18,22 @@ namespace Microsoft.Framework.ConfigurationModel
         {
             var json = @"
 {
-    'name': 'test',
-    'address': {
-        'street': 'Something street',
-        'zipcode': '12345'
-    }
+    'firstname': 'test',
+    'test.last.name': 'last.name',
+        'residential.address': {
+            'street.name': 'Something street',
+            'zipcode': '12345'
+        }
 }";
             var jsonConfigSrc = new JsonConfigurationSource(ArbitraryFilePath);
 
             jsonConfigSrc.Load(StringToStream(json));
 
-            Assert.Equal(3, jsonConfigSrc.Data.Count);
-            Assert.Equal("test", jsonConfigSrc.Data["NAME"]);
-            Assert.Equal("Something street", jsonConfigSrc.Data["address:STREET"]);
-            Assert.Equal("12345", jsonConfigSrc.Data["address:zipcode"]);
+            Assert.Equal(4, jsonConfigSrc.Data.Count);
+            Assert.Equal("test", jsonConfigSrc.Data["firstname"]);
+            Assert.Equal("last.name", jsonConfigSrc.Data["test.last.name"]);
+            Assert.Equal("Something street", jsonConfigSrc.Data["residential.address:STREET.name"]);
+            Assert.Equal("12345", jsonConfigSrc.Data["residential.address:zipcode"]);
         }
 
         [Fact]

--- a/test/Microsoft.Framework.ConfigurationModel.Xml.Test/XmlConfigurationSourceTest.cs
+++ b/test/Microsoft.Framework.ConfigurationModel.Xml.Test/XmlConfigurationSourceTest.cs
@@ -18,26 +18,26 @@ namespace Microsoft.Framework.ConfigurationModel
         {
             var xml = @"
                 <settings>
-                    <Data>
+                    <Data.Setting>
                         <DefaultConnection>
-                            <ConnectionString>TestConnectionString</ConnectionString>
+                            <Connection.String>Test.Connection.String</Connection.String>
                             <Provider>SqlClient</Provider>
                         </DefaultConnection>
                         <Inventory>
                             <ConnectionString>AnotherTestConnectionString</ConnectionString>
                             <Provider>MySql</Provider>
                         </Inventory>
-                    </Data>
+                    </Data.Setting>
                 </settings>";
             var xmlConfigSrc = new XmlConfigurationSource(ArbitraryFilePath);
 
             xmlConfigSrc.Load(StringToStream(xml));
 
             Assert.Equal(4, xmlConfigSrc.Data.Count);
-            Assert.Equal("TestConnectionString", xmlConfigSrc.Data["DATA:DEFAULTCONNECTION:CONNECTIONSTRING"]);
-            Assert.Equal("SqlClient", xmlConfigSrc.Data["DATA:DefaultConnection:Provider"]);
-            Assert.Equal("AnotherTestConnectionString", xmlConfigSrc.Data["data:inventory:connectionstring"]);
-            Assert.Equal("MySql", xmlConfigSrc.Data["Data:Inventory:Provider"]);
+            Assert.Equal("Test.Connection.String", xmlConfigSrc.Data["DATA.SETTING:DEFAULTCONNECTION:CONNECTION.STRING"]);
+            Assert.Equal("SqlClient", xmlConfigSrc.Data["DATA.SETTING:DefaultConnection:Provider"]);
+            Assert.Equal("AnotherTestConnectionString", xmlConfigSrc.Data["data.setting:inventory:connectionstring"]);
+            Assert.Equal("MySql", xmlConfigSrc.Data["Data.setting:Inventory:Provider"]);
         }
 
         [Fact]


### PR DESCRIPTION
This addresses the below bugs:
https://github.com/aspnet/Configuration/issues/126
https://github.com/aspnet/Configuration/issues/106

Currently to represent a JSON element's path from the top node we use ':' as a delimiter. For example:

```
{
 "one":
 {
  "two": "two value"
 }
}
```

The convention to identify "two" here is one:two. This works fine for normal scenarios as we get the JSON node's Path which is one.two and replace the '.' => ':'.

This fails when the node name contains a '.'. For example replace the name of 'two' to 'a.b', JSON.net escapes such a node's name to ['a.b']. So our code replacing all '.' => ':' will mess up the key name.

This fix addresses the problem by replacing '.' => ':' only if it is not with in ['..'].

/CC @ChengTian @Eilon @mikary 