### PR TITLE
Added extension to accept switchMappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,5 @@ This project is part of ASP.NET 5. You can find samples, documentation and getti
 ## Docs and samples
 
 * [ASP.NET 5 Moving Parts: IConfiguration](http://whereslou.com/2014/05/23/asp-net-vnext-moving-parts-iconfiguration/)
+* [ASP.NET 5 Configuration - Microsoft.Framework.ConfigurationModel](http://blog.jsinh.in/asp-net-5-configuration-microsoft-framework-configurationmodel/)
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Configuration is a framework for accessing Key/Value based configuration setting
 
 This project is part of ASP.NET 5. You can find samples, documentation and getting started instructions for ASP.NET 5 at the [Home](https://github.com/aspnet/home) repo.
 
-## Docs and samples
+## Blog posts
 
 * [ASP.NET 5 Moving Parts: IConfiguration](http://whereslou.com/2014/05/23/asp-net-vnext-moving-parts-iconfiguration/)
 * [ASP.NET 5 Configuration - Microsoft.Framework.ConfigurationModel](http://blog.jsinh.in/asp-net-5-configuration-microsoft-framework-configurationmodel/)

--- a/src/Microsoft.Framework.ConfigurationModel/ConfigurationExtensions.cs
+++ b/src/Microsoft.Framework.ConfigurationModel/ConfigurationExtensions.cs
@@ -29,6 +29,12 @@ namespace Microsoft.Framework.ConfigurationModel
             configuration.Add(new CommandLineConfigurationSource(args));
             return configuration;
         }
+        
+        public static IConfigurationSourceContainer AddCommandLine(this IConfigurationSourceContainer configuration, string[] args, IDictionary<string, string> switchMappings)
+        {
+            configuration.Add(new CommandLineConfigurationSource(args, switchMappings));
+            return configuration;
+        }
 
         public static IConfigurationSourceContainer AddEnvironmentVariables(this IConfigurationSourceContainer configuration)
         {


### PR DESCRIPTION
Added extension to accept switchMappings along with command line arguments for command line configuration source.

I took some time to surprisingly observe that `switchMappings` part was implemented via `CommandLineConfigurationSource` ctor but `ConfigurationExtensions` didn't had option to feed them during `AddCommandLine`.

I even see `using System.Collections.Generic;` in `ConfigurationExtensions` which is unused. Seems like implementation is in place along with few Unit Tests which passes. But no option to use `switchMappings`.

P.S - My first PR, excited. (Already signed Contributor License Agreement)