### PR TITLE
Add support for encrypted XML-based config

### DIFF
--- a/src/Microsoft.Framework.ConfigurationModel.Xml/EncryptedXmlDocumentDecryptor.cs
+++ b/src/Microsoft.Framework.ConfigurationModel.Xml/EncryptedXmlDocumentDecryptor.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if !ASPNETCORE50
+using System;
+using System.Security.Cryptography.Xml;
+using System.Xml;
+
+namespace Microsoft.Framework.ConfigurationModel
+{
+    /// <summary>
+    /// A decryptor that uses the EncryptedXml class in the desktop CLR.
+    /// </summary>
+    internal sealed class EncryptedXmlDocumentDecryptor : XmlDocumentDecryptor
+    {
+        private readonly Func<XmlDocument, EncryptedXml> _encryptedXmlFactory;
+
+        internal EncryptedXmlDocumentDecryptor()
+            : this(DefaultEncryptedXmlFactory)
+        {
+        }
+
+        internal EncryptedXmlDocumentDecryptor(Func<XmlDocument, EncryptedXml> encryptedXmlFactory)
+        {
+            _encryptedXmlFactory = encryptedXmlFactory;
+        }
+
+        protected override XmlReader DecryptDocumentAndCreateXmlReader(XmlDocument document)
+        {
+            // Perform the actual decryption step, updating the XmlDocument in-place.
+            var encryptedXml = _encryptedXmlFactory(document);
+            encryptedXml.DecryptDocument();
+
+            // Finally, return the new XmlReader from the updated XmlDocument.
+            // Error messages based on this XmlReader won't show line numbers,
+            // but that's fine since we transformed the document anyway.
+            return document.CreateNavigator().ReadSubtree();
+        }
+
+        private static EncryptedXml DefaultEncryptedXmlFactory(XmlDocument document)
+        {
+            return new EncryptedXml(document);
+        }
+    }
+}
+#endif

--- a/src/Microsoft.Framework.ConfigurationModel.Xml/Properties/Resources.Designer.cs
+++ b/src/Microsoft.Framework.ConfigurationModel.Xml/Properties/Resources.Designer.cs
@@ -43,6 +43,22 @@ namespace Microsoft.Framework.ConfigurationModel.Xml
         }
 
         /// <summary>
+        /// Encrypted XML is not supported on this platform.
+        /// </summary>
+        internal static string Error_EncryptedXmlNotSupported
+        {
+            get { return GetString("Error_EncryptedXmlNotSupported"); }
+        }
+
+        /// <summary>
+        /// Encrypted XML is not supported on this platform.
+        /// </summary>
+        internal static string FormatError_EncryptedXmlNotSupported()
+        {
+            return GetString("Error_EncryptedXmlNotSupported");
+        }
+
+        /// <summary>
         /// File path must be a non-empty string.
         /// </summary>
         internal static string Error_InvalidFilePath

--- a/src/Microsoft.Framework.ConfigurationModel.Xml/Resources.resx
+++ b/src/Microsoft.Framework.ConfigurationModel.Xml/Resources.resx
@@ -123,6 +123,9 @@
   <data name="Error_CommitWhenNewKeyFound" xml:space="preserve">
     <value>Unable to commit because a new key was added to the configuration file after last load operation. The newly added key is '{0}'.</value>
   </data>
+  <data name="Error_EncryptedXmlNotSupported" xml:space="preserve">
+    <value>Encrypted XML is not supported on this platform.</value>
+  </data>
   <data name="Error_InvalidFilePath" xml:space="preserve">
     <value>File path must be a non-empty string.</value>
   </data>

--- a/src/Microsoft.Framework.ConfigurationModel.Xml/XmlDocumentDecryptor.cs
+++ b/src/Microsoft.Framework.ConfigurationModel.Xml/XmlDocumentDecryptor.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Xml;
+using Microsoft.Framework.ConfigurationModel.Xml;
+
+namespace Microsoft.Framework.ConfigurationModel
+{
+    internal class XmlDocumentDecryptor
+    {
+        /// <summary>
+        /// Accesses the singleton decryptor instance.
+        /// </summary>
+#if ASPNETCORE50
+        public static readonly XmlDocumentDecryptor Instance = new XmlDocumentDecryptor();
+#else
+        public static readonly XmlDocumentDecryptor Instance = new EncryptedXmlDocumentDecryptor();
+#endif
+
+        // don't create an instance of this directly
+        protected XmlDocumentDecryptor()
+        {
+        }
+
+        private static bool ContainsEncryptedData(XmlDocument document)
+        {
+            // EncryptedXml will simply decrypt the document in-place without telling
+            // us that it did so, so we need to perform a check to see if EncryptedXml
+            // will actually do anything. The below check for an encrypted data blob
+            // is the same one that EncryptedXml would have performed.
+#if ASPNETCORE50
+            var matchingNodes = document.GetElementsByTagName("EncryptedData", "http://www.w3.org/2001/04/xmlenc#");
+            return (matchingNodes != null && matchingNodes.Count > 0);
+#else
+            var namespaceManager = new XmlNamespaceManager(document.NameTable);
+            namespaceManager.AddNamespace("enc", "http://www.w3.org/2001/04/xmlenc#");
+            return (document.SelectSingleNode("//enc:EncryptedData", namespaceManager) != null);
+#endif
+        }
+
+        /// <summary>
+        /// Returns an XmlReader that decrypts data transparently.
+        /// </summary>
+        public XmlReader CreateDecryptingXmlReader(Stream input, XmlReaderSettings settings)
+        {
+            // XML-based configurations aren't really all that big, so we can buffer
+            // the whole thing in memory while we determine decryption operations.
+            var memStream = new MemoryStream();
+            input.CopyTo(memStream);
+            memStream.Position = 0;
+
+            // First, consume the entire XmlReader as an XmlDocument.
+            var document = new XmlDocument();
+            using (var reader = XmlReader.Create(memStream, settings))
+            {
+                document.Load(reader);
+            }
+            memStream.Position = 0;
+
+            if (ContainsEncryptedData(document))
+            {
+                return DecryptDocumentAndCreateXmlReader(document);
+            }
+            else
+            {
+                // If no decryption would have taken place, return a new fresh reader
+                // based on the memory stream (which doesn't need to be disposed).
+                return XmlReader.Create(memStream, settings);
+            }
+        }
+
+        protected virtual XmlReader DecryptDocumentAndCreateXmlReader(XmlDocument document)
+        {
+            // by default we don't know how to process encrypted XML
+            throw new PlatformNotSupportedException(Resources.Error_EncryptedXmlNotSupported);
+        }
+    }
+}

--- a/src/Microsoft.Framework.ConfigurationModel.Xml/project.json
+++ b/src/Microsoft.Framework.ConfigurationModel.Xml/project.json
@@ -8,16 +8,19 @@
     "frameworks": {
         "net45": {
             "frameworkAssemblies": {
+                "System.Security": "",
                 "System.Xml": ""
             }
         },
         "aspnet50": {
             "frameworkAssemblies": {
+                "System.Security": "",
                 "System.Xml": ""
             }
         },
         "aspnetcore50": {
             "dependencies": {
+                "System.Xml.XmlDocument": "4.0.0-beta-*",
                 "System.Xml.XmlSerializer": "4.0.10-beta-*"
             }
         }

--- a/test/Microsoft.Framework.ConfigurationModel.Xml.Test/XmlConfigurationSourceTest.AspNet50.cs
+++ b/test/Microsoft.Framework.ConfigurationModel.Xml.Test/XmlConfigurationSourceTest.AspNet50.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if !ASPNETCORE50
+// These tests only run on desktop CLR.
+
+using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.Xml;
+using System.Xml;
+using Xunit;
+
+namespace Microsoft.Framework.ConfigurationModel
+{
+    public partial class XmlConfigurationSourceTest
+    {
+        [Fact]
+        public void LoadKeyValuePairsFromValidEncryptedXml()
+        {
+            var xml = @"
+                <settings>
+                    <Data.Setting>
+                        <DefaultConnection>
+                            <Connection.String>Test.Connection.String</Connection.String>
+                            <Provider>SqlClient</Provider>
+                        </DefaultConnection>
+                        <Inventory>
+                            <ConnectionString>AnotherTestConnectionString</ConnectionString>
+                            <Provider>MySql</Provider>
+                        </Inventory>
+                    </Data.Setting>
+                </settings>";
+
+            // This AES key will be used to encrypt the 'Inventory' element
+            var aes = Aes.Create();
+            aes.KeySize = 128;
+            aes.GenerateKey();
+
+            // Perform the encryption
+            var xmlDocument = new XmlDocument();
+            xmlDocument.LoadXml(xml);
+            var encryptedXml = new EncryptedXml(xmlDocument);
+            encryptedXml.AddKeyNameMapping("myKey", aes);
+            var elementToEncrypt = (XmlElement)xmlDocument.SelectSingleNode("//Inventory");
+            EncryptedXml.ReplaceElement(elementToEncrypt, encryptedXml.Encrypt(elementToEncrypt, "myKey"), content: false);
+
+            // Quick sanity check: the document should no longer contain an 'Inventory' element
+            Assert.Null(xmlDocument.SelectSingleNode("//Inventory"));
+
+            // Arrange
+            var xmlConfigSrc = new XmlConfigurationSource(ArbitraryFilePath, new EncryptedXmlDocumentDecryptor(doc =>
+            {
+                var innerEncryptedXml = new EncryptedXml(doc);
+                innerEncryptedXml.AddKeyNameMapping("myKey", aes);
+                return innerEncryptedXml;
+            }));
+
+            // Act
+            xmlConfigSrc.Load(StringToStream(xmlDocument.OuterXml));
+
+            // Assert
+            Assert.Equal("Test.Connection.String", xmlConfigSrc.Get("DATA.SETTING:DEFAULTCONNECTION:CONNECTION.STRING"));
+            Assert.Equal("SqlClient", xmlConfigSrc.Get("DATA.SETTING:DefaultConnection:Provider"));
+            Assert.Equal("AnotherTestConnectionString", xmlConfigSrc.Get("data.setting:inventory:connectionstring"));
+            Assert.Equal("MySql", xmlConfigSrc.Get("Data.setting:Inventory:Provider"));
+        }
+    }
+}
+#endif

--- a/test/Microsoft.Framework.ConfigurationModel.Xml.Test/XmlConfigurationSourceTest.AspNetCore50.cs
+++ b/test/Microsoft.Framework.ConfigurationModel.Xml.Test/XmlConfigurationSourceTest.AspNetCore50.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if ASPNETCORE50
+// These tests only run on Core CLR.
+
+using System;
+using Microsoft.Framework.ConfigurationModel.Xml;
+using Xunit;
+
+namespace Microsoft.Framework.ConfigurationModel
+{
+    public partial class XmlConfigurationSourceTest
+    {
+        [Fact]
+        public void LoadKeyValuePairsFromValidEncryptedXml_ThrowsPlatformNotSupported()
+        {
+            var xml = @"
+                <settings>
+                    <Data.Setting>
+                        <DefaultConnection>
+                            <Connection.String>Test.Connection.String</Connection.String>
+                            <Provider>SqlClient</Provider>
+                        </DefaultConnection>
+                        <Inventory>
+                            <EncryptedData Type=""http://www.w3.org/2001/04/xmlenc#Element"" xmlns=""http://www.w3.org/2001/04/xmlenc#"">
+                            <EncryptionMethod Algorithm=""http://www.w3.org/2001/04/xmlenc#aes256-cbc"" />
+                            <KeyInfo xmlns=""http://www.w3.org/2000/09/xmldsig#"">
+                                <EncryptedKey xmlns=""http://www.w3.org/2001/04/xmlenc#"">
+                                <EncryptionMethod Algorithm=""http://www.w3.org/2001/04/xmlenc#kw-aes256"" />
+                                <KeyInfo xmlns=""http://www.w3.org/2000/09/xmldsig#"">
+                                    <KeyName>myKey</KeyName>
+                                </KeyInfo>
+                                <CipherData>
+                                    <CipherValue>b0dxJI/o00vZgTNOJ6wUt0/6wCKWlQANAYE8cBsEzok4LQma7ErEnA==</CipherValue>
+                                </CipherData>
+                                </EncryptedKey>
+                            </KeyInfo>
+                            <CipherData>
+                                <CipherValue>iXzecb+Cha80LLrl4zON3o7HfpRc0NxlJsnBb6zbKFa1HqtNhy2VrTnrEsZUViBWRkRbl+MCix7TiaIs4NtLijNU5Ob8Ez3vcD4T/QcmPywBYJDJhj1OUUeJSKH+icjg</CipherValue>
+                            </CipherData>
+                            </EncryptedData>
+                            <Provider>MySql</Provider>
+                        </Inventory>
+                    </Data.Setting>
+                </settings>";
+
+            // Arrange
+            var xmlConfigSrc = new XmlConfigurationSource(ArbitraryFilePath);
+
+            // Act & assert
+            var ex = Assert.Throws<PlatformNotSupportedException>(() => xmlConfigSrc.Load(StringToStream(xml)));
+            Assert.Equal(Resources.Error_EncryptedXmlNotSupported, ex.Message);
+        }
+    }
+}
+#endif

--- a/test/Microsoft.Framework.ConfigurationModel.Xml.Test/XmlConfigurationSourceTest.cs
+++ b/test/Microsoft.Framework.ConfigurationModel.Xml.Test/XmlConfigurationSourceTest.cs
@@ -9,7 +9,7 @@ using Resources = Microsoft.Framework.ConfigurationModel.Xml.Resources;
 
 namespace Microsoft.Framework.ConfigurationModel
 {
-    public class XmlConfigurationSourceTest
+    public partial class XmlConfigurationSourceTest
     {
         private static readonly string ArbitraryFilePath = "Unit tests do not touch file system";
 


### PR DESCRIPTION
Currently only desktop CLR supports this pending EncryptedXml being checked in to Core CLR.

/cc @glennc @blowdart @victorhurdugaci 