### PR TITLE
Final API review changes

### DIFF
--- a/src/Microsoft.Framework.ConfigurationModel.Interfaces/IConfiguration.cs
+++ b/src/Microsoft.Framework.ConfigurationModel.Interfaces/IConfiguration.cs
@@ -24,8 +24,6 @@ namespace Microsoft.Framework.ConfigurationModel
 
         IEnumerable<KeyValuePair<string, IConfiguration>> GetSubKeys(string key);
 
-        void Reload();
-
         void Set(string key, string value);
     }
 }

--- a/src/Microsoft.Framework.ConfigurationModel.Interfaces/IConfigurationSourceRoot.cs
+++ b/src/Microsoft.Framework.ConfigurationModel.Interfaces/IConfigurationSourceRoot.cs
@@ -5,8 +5,12 @@ using System.Collections.Generic;
 
 namespace Microsoft.Framework.ConfigurationModel
 {
-    public interface IConfigurationSourceContainer : IConfiguration, IEnumerable<IConfigurationSource>
+    public interface IConfigurationSourceRoot : IConfiguration
     {
-        IConfigurationSourceContainer Add(IConfigurationSource configurationSource);
+        IEnumerable<IConfigurationSource> Sources { get; }
+
+        IConfigurationSourceRoot Add(IConfigurationSource configurationSource);
+
+        void Reload();
     }
 }

--- a/src/Microsoft.Framework.ConfigurationModel.Json/JsonConfigurationExtension.cs
+++ b/src/Microsoft.Framework.ConfigurationModel.Json/JsonConfigurationExtension.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Framework.ConfigurationModel
 {
     public static class JsonConfigurationExtension
     {
-        public static IConfigurationSourceContainer AddJsonFile(this IConfigurationSourceContainer configuration, string path)
+        public static IConfigurationSourceRoot AddJsonFile(this IConfigurationSourceRoot configuration, string path)
         {
             configuration.Add(new JsonConfigurationSource(path));
             return configuration;

--- a/src/Microsoft.Framework.ConfigurationModel.Xml/XmlConfigurationExtension.cs
+++ b/src/Microsoft.Framework.ConfigurationModel.Xml/XmlConfigurationExtension.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Framework.ConfigurationModel
 {
     public static class XmlConfigurationExtension
     {
-        public static IConfigurationSourceContainer AddXmlFile(this IConfigurationSourceContainer configuration, string path)
+        public static IConfigurationSourceRoot AddXmlFile(this IConfigurationSourceRoot configuration, string path)
         {
             configuration.Add(new XmlConfigurationSource(path));
             return configuration;

--- a/src/Microsoft.Framework.ConfigurationModel/Configuration.cs
+++ b/src/Microsoft.Framework.ConfigurationModel/Configuration.cs
@@ -8,12 +8,19 @@ using System.Linq;
 
 namespace Microsoft.Framework.ConfigurationModel
 {
-    public class Configuration : IConfiguration, IConfigurationSourceContainer
+    public class Configuration : IConfiguration, IConfigurationSourceRoot
     {
         private readonly IList<IConfigurationSource> _sources = new List<IConfigurationSource>();
-      
-        public Configuration()
+
+        public Configuration(params IConfigurationSource[] sources)
         {
+            if (sources != null)
+            {
+                foreach (IConfigurationSource singleSource in sources)
+                {
+                    Add(singleSource);
+                }
+            }
         }
 
         public string this[string key]
@@ -25,6 +32,14 @@ namespace Microsoft.Framework.ConfigurationModel
             set
             {
                 Set(key, value);
+            }
+        }
+
+        public IEnumerable<IConfigurationSource> Sources
+        {
+            get
+            {
+                return _sources;
             }
         }
 
@@ -109,26 +124,16 @@ namespace Microsoft.Framework.ConfigurationModel
                 new ConfigurationFocus(this, prefix + segment + Constants.KeyDelimiter));
         }
 
-        public IConfigurationSourceContainer Add(IConfigurationSource configurationSource)
+        public IConfigurationSourceRoot Add(IConfigurationSource configurationSource)
         {
             configurationSource.Load();
             return AddLoadedSource(configurationSource);
         }
 
-        internal IConfigurationSourceContainer AddLoadedSource(IConfigurationSource configurationSource)
+        internal IConfigurationSourceRoot AddLoadedSource(IConfigurationSource configurationSource)
         {
             _sources.Add(configurationSource);
             return this;
-        }
-
-        public IEnumerator<IConfigurationSource> GetEnumerator()
-        {
-            return _sources.GetEnumerator();
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
         }
     }
 }

--- a/src/Microsoft.Framework.ConfigurationModel/ConfigurationExtensions.cs
+++ b/src/Microsoft.Framework.ConfigurationModel/ConfigurationExtensions.cs
@@ -17,26 +17,26 @@ namespace Microsoft.Framework.ConfigurationModel
 
 
 #if NET45 || ASPNET50 || ASPNETCORE50
-        public static IConfigurationSourceContainer AddIniFile(this IConfigurationSourceContainer configuration, string path)
+        public static IConfigurationSourceRoot AddIniFile(this IConfigurationSourceRoot configuration, string path)
         {
             configuration.Add(new IniFileConfigurationSource(path));
             return configuration;
         }
 #endif
 
-        public static IConfigurationSourceContainer AddCommandLine(this IConfigurationSourceContainer configuration, string[] args)
+        public static IConfigurationSourceRoot AddCommandLine(this IConfigurationSourceRoot configuration, string[] args)
         {
             configuration.Add(new CommandLineConfigurationSource(args));
             return configuration;
         }
 
-        public static IConfigurationSourceContainer AddEnvironmentVariables(this IConfigurationSourceContainer configuration)
+        public static IConfigurationSourceRoot AddEnvironmentVariables(this IConfigurationSourceRoot configuration)
         {
             configuration.Add(new EnvironmentVariablesConfigurationSource());
             return configuration;
         }
 
-        public static IConfigurationSourceContainer AddEnvironmentVariables(this IConfigurationSourceContainer configuration, string prefix)
+        public static IConfigurationSourceRoot AddEnvironmentVariables(this IConfigurationSourceRoot configuration, string prefix)
         {
             configuration.Add(new EnvironmentVariablesConfigurationSource(prefix));
             return configuration;

--- a/src/Microsoft.Framework.ConfigurationModel/ConfigurationFocus.cs
+++ b/src/Microsoft.Framework.ConfigurationModel/ConfigurationFocus.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.Framework.ConfigurationModel
 {
-    public class ConfigurationFocus : IConfiguration
+    internal class ConfigurationFocus : IConfiguration
     {
         private readonly string _prefix;
         private readonly IConfiguration _root;
@@ -61,11 +61,6 @@ namespace Microsoft.Framework.ConfigurationModel
         public void Set(string key, string value)
         {
             _root.Set(_prefix + key, value);
-        }
-
-        public void Reload()
-        {
-            _root.Reload();
         }
 
         public IEnumerable<KeyValuePair<string, IConfiguration>> GetSubKeys()

--- a/src/Microsoft.Framework.ConfigurationModel/Sources/CommandLineConfigurationSource.cs
+++ b/src/Microsoft.Framework.ConfigurationModel/Sources/CommandLineConfigurationSource.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.Framework.ConfigurationModel
 {
@@ -10,11 +11,11 @@ namespace Microsoft.Framework.ConfigurationModel
     {
         private readonly Dictionary<string, string> _switchMappings;
 
-        public CommandLineConfigurationSource(string[] args, IDictionary<string, string> switchMappings = null)
+        public CommandLineConfigurationSource(IEnumerable<string> args, IDictionary<string, string> switchMappings = null)
         {
             if (args == null)
             {
-                throw new ArgumentNullException("args");
+                throw new ArgumentNullException(nameof(args));
             }
 
             Args = args;
@@ -25,7 +26,7 @@ namespace Microsoft.Framework.ConfigurationModel
             }
         }
 
-        public string[] Args { get; private set; }
+        protected IEnumerable<string> Args { get; private set; }
 
         public override void Load()
         {
@@ -33,9 +34,9 @@ namespace Microsoft.Framework.ConfigurationModel
             string key, value;
             var argIndex = 0;
 
-            while (argIndex < Args.Length)
+            while (argIndex < Args.Count())
             {
-                var currentArg = Args[argIndex];
+                var currentArg = Args.ElementAt(argIndex);
                 var keyStartIndex = 0;
 
                 if (currentArg.StartsWith("--"))
@@ -82,12 +83,12 @@ namespace Microsoft.Framework.ConfigurationModel
 
                     argIndex++;
 
-                    if (argIndex == Args.Length)
+                    if (argIndex == Args.Count())
                     {
-                        throw new FormatException(Resources.FormatError_ValueIsMissing(Args[argIndex - 1]));
+                        throw new FormatException(Resources.FormatError_ValueIsMissing(Args.ElementAt(argIndex - 1)));
                     }
 
-                    value = Args[argIndex];
+                    value = Args.ElementAt(argIndex);
                 }
                 else
                 {
@@ -131,14 +132,16 @@ namespace Microsoft.Framework.ConfigurationModel
                 // Only keys start with "--" or "-" are acceptable
                 if (!mapping.Key.StartsWith("-") && !mapping.Key.StartsWith("--"))
                 {
-                    throw new ArgumentException(Resources.FormatError_InvalidSwitchMapping(mapping.Key),
-                        "switchMappings");
+                    throw new ArgumentException(
+                        Resources.FormatError_InvalidSwitchMapping(mapping.Key),
+                        nameof(switchMappings));
                 }
 
                 if (switchMappingsCopy.ContainsKey(mapping.Key))
                 {
-                    throw new ArgumentException(Resources.FormatError_DuplicatedKeyInSwitchMappings(mapping.Key),
-                        "switchMappings");
+                    throw new ArgumentException(
+                        Resources.FormatError_DuplicatedKeyInSwitchMappings(mapping.Key),
+                        nameof(switchMappings));
                 }
 
                 switchMappingsCopy.Add(mapping.Key, mapping.Value);

--- a/test/Microsoft.Framework.ConfigurationModel.FunctionalTests/ConfigurationTests.cs
+++ b/test/Microsoft.Framework.ConfigurationModel.FunctionalTests/ConfigurationTests.cs
@@ -151,7 +151,7 @@ CommonKey3:CommonKey4=IniValue6";
             config.Set("CommonKey1:CommonKey2:CommonKey3:CommonKey4", "NewValue");
 
             // All config sources must be updated
-            foreach (var src in config)
+            foreach (var src in config.Sources)
             {
                 Assert.Equal("NewValue",
                     (src as ConfigurationSource).Get("CommonKey1:CommonKey2:CommonKey3:CommonKey4"));
@@ -165,7 +165,7 @@ CommonKey3:CommonKey4=IniValue6";
             config["CommonKey1:CommonKey2:CommonKey3:CommonKey4"] = "NewValue";
 
             // All config sources must be updated
-            foreach (var src in config)
+            foreach (var src in config.Sources)
             {
                 Assert.Equal("NewValue",
                     (src as ConfigurationSource).Get("CommonKey1:CommonKey2:CommonKey3:CommonKey4"));

--- a/test/Microsoft.Framework.ConfigurationModel.Test/ConfigurationTest.cs
+++ b/test/Microsoft.Framework.ConfigurationModel.Test/ConfigurationTest.cs
@@ -48,9 +48,9 @@ namespace Microsoft.Framework.ConfigurationModel
             memRet3 = config.TryGet("MEM3:KEYINMEM3", out memVal3);
 
             // Assert
-            Assert.Contains(memConfigSrc1, config);
-            Assert.Contains(memConfigSrc2, config);
-            Assert.Contains(memConfigSrc3, config);
+            Assert.Contains(memConfigSrc1, config.Sources);
+            Assert.Contains(memConfigSrc2, config.Sources);
+            Assert.Contains(memConfigSrc3, config.Sources);
 
             Assert.True(memRet1);
             Assert.True(memRet2);
@@ -257,7 +257,7 @@ namespace Microsoft.Framework.ConfigurationModel
             config.AddLoadedSource(memConfigSrc3);
 
             // Assert
-            var enumerator = config.GetEnumerator();
+            var enumerator = config.Sources.GetEnumerator();
             int srcCount = 0;
             while (enumerator.MoveNext())
             {
@@ -297,7 +297,7 @@ namespace Microsoft.Framework.ConfigurationModel
             var enumerable = config as IEnumerable;
 
             // Assert
-            var enumerator = config.GetEnumerator();
+            var enumerator = config.Sources.GetEnumerator();
             int srcCount = 0;
             while (enumerator.MoveNext())
             {


### PR DESCRIPTION
- IConfigurationSourceContainer renamed to IConfigurationSourceRoot
- IConfigurationSourceRoot is no longer an IEnumerable
- Added Sources property to IConfigurationSourceRoot
- Moved Reload() from IConfiguration to IConfigurationSourceRoot
- Make ConfigurationFocus internal
- Configuration class constructor accepts params IConfigurationSource[]
- CommandLineConfigurationSource accepts IEnumerable instead of string array
- CommandLineConfigurationSource's args property is protected

Fixes https://github.com/aspnet/Configuration/issues/144
Fixes https://github.com/aspnet/Configuration/issues/142
Fixes https://github.com/aspnet/Configuration/issues/141
Fixes https://github.com/aspnet/Configuration/issues/140

cc @glennc 