### PR TITLE
Replace portable target with netcore451

### DIFF
--- a/src/Microsoft.Framework.ConfigurationModel.Interfaces/project.json
+++ b/src/Microsoft.Framework.ConfigurationModel.Interfaces/project.json
@@ -10,7 +10,7 @@
                 "System.Linq": "4.0.0-beta-*"
             }
         },
-        ".NETPortable,Version=v4.6,Profile=Profile151": {
+        "netcore451": {
             "frameworkAssemblies": {
                 "System.Collections": "",
                 "System.Diagnostics.Debug": "",

--- a/src/Microsoft.Framework.ConfigurationModel/project.json
+++ b/src/Microsoft.Framework.ConfigurationModel/project.json
@@ -19,7 +19,7 @@
         "System.Runtime.InteropServices": "4.0.20-beta-*"
       }
     },
-    ".NETPortable,Version=v4.6,Profile=Profile151": {
+    "netcore451": {
       "frameworkAssemblies": {
         "System.Collections": "",
         "System.Diagnostics.Debug": "",


### PR DESCRIPTION
(This will collapse into `core50` when DNX and the Tools for Windows 10 support it.)