### PR TITLE
Remove IVT for some unit tests

### DIFF
--- a/src/Microsoft.Framework.ConfigurationModel/Configuration.cs
+++ b/src/Microsoft.Framework.ConfigurationModel/Configuration.cs
@@ -136,14 +136,29 @@ namespace Microsoft.Framework.ConfigurationModel
                 new ConfigurationFocus(this, prefix + segment + Constants.KeyDelimiter));
         }
 
+        /// <summary>
+        /// Adds a new configuration source.
+        /// </summary>
+        /// <param name="configurationSource">The configuration source to add.</param>
+        /// <returns>The same configuration source.</returns>
         public IConfigurationSourceRoot Add(IConfigurationSource configurationSource)
         {
-            configurationSource.Load();
-            return AddLoadedSource(configurationSource);
+            return Add(configurationSource, load: true);
         }
 
-        internal IConfigurationSourceRoot AddLoadedSource(IConfigurationSource configurationSource)
+        /// <summary>
+        /// Adds a new configuration source.
+        /// </summary>
+        /// <param name="configurationSource">The configuration source to add.</param>
+        /// <param name="load">If true, the configuration source's <see cref="IConfigurationSource.Load"/> method will be called.</param>
+        /// <returns>The same configuration source.</returns>
+        /// <remarks>This method is intended only for test scenarios.</remarks>
+        public IConfigurationSourceRoot Add(IConfigurationSource configurationSource, bool load)
         {
+            if (load)
+            {
+                configurationSource.Load();
+            }
             _sources.Add(configurationSource);
             return this;
         }

--- a/src/Microsoft.Framework.ConfigurationModel/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Framework.ConfigurationModel/Properties/AssemblyInfo.cs
@@ -39,6 +39,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
 [assembly: InternalsVisibleTo("Microsoft.Framework.ConfigurationModel.Test")]
-[assembly: InternalsVisibleTo("Microsoft.Framework.ConfigurationModel.Json.Test")]
 [assembly: NeutralResourcesLanguage("en-US")]
 [assembly: AssemblyMetadata("Serviceable", "True")]

--- a/test/Microsoft.Framework.ConfigurationModel.Json.Test/ArrayTest.cs
+++ b/test/Microsoft.Framework.ConfigurationModel.Json.Test/ArrayTest.cs
@@ -102,8 +102,8 @@ namespace Microsoft.Framework.ConfigurationModel.Json.Test
             jsonConfigSource2.Load(TestStreamHelpers.StringToStream(json2));
 
             var config = new Configuration();
-            config.AddLoadedSource(jsonConfigSource1);
-            config.AddLoadedSource(jsonConfigSource2);
+            config.Add(jsonConfigSource1, load: false);
+            config.Add(jsonConfigSource2, load: false);
 
             Assert.Equal(3, config.GetSubKeys("ip").Count());
             Assert.Equal("15.16.17.18", config.Get("ip:0"));
@@ -135,8 +135,8 @@ namespace Microsoft.Framework.ConfigurationModel.Json.Test
             jsonConfigSource2.Load(TestStreamHelpers.StringToStream(json2));
 
             var config = new Configuration();
-            config.AddLoadedSource(jsonConfigSource1);
-            config.AddLoadedSource(jsonConfigSource2);
+            config.Add(jsonConfigSource1, load: false);
+            config.Add(jsonConfigSource2, load: false);
 
             Assert.Equal(3, config.GetSubKeys("ip").Count());
             Assert.Equal("1.2.3.4", config.Get("ip:0"));
@@ -168,8 +168,8 @@ namespace Microsoft.Framework.ConfigurationModel.Json.Test
             jsonConfigSource2.Load(TestStreamHelpers.StringToStream(json2));
 
             var config = new Configuration();
-            config.AddLoadedSource(jsonConfigSource1);
-            config.AddLoadedSource(jsonConfigSource2);
+            config.Add(jsonConfigSource1, load: false);
+            config.Add(jsonConfigSource2, load: false);
 
             Assert.Equal(4, config.GetSubKeys("ip").Count());
             Assert.Equal("1.2.3.4", config.Get("ip:0"));
@@ -193,7 +193,7 @@ namespace Microsoft.Framework.ConfigurationModel.Json.Test
             jsonConfigSource.Load(TestStreamHelpers.StringToStream(json));
 
             var config = new Configuration();
-            config.AddLoadedSource(jsonConfigSource);
+            config.Add(jsonConfigSource, load: false);
 
             var subkey = config.GetSubKey("setting");
             var indexSubkeys = subkey.GetSubKeys().ToArray();
@@ -222,7 +222,7 @@ namespace Microsoft.Framework.ConfigurationModel.Json.Test
             jsonConfigSource.Load(TestStreamHelpers.StringToStream(json));
 
             var config = new Configuration();
-            config.AddLoadedSource(jsonConfigSource);
+            config.Add(jsonConfigSource, load: false);
 
             var subkey = config.GetSubKey("setting");
             var indexSubkeys = subkey.GetSubKeys().ToArray();

--- a/test/Microsoft.Framework.ConfigurationModel.Json.Test/JsonConfigurationSourceTest.cs
+++ b/test/Microsoft.Framework.ConfigurationModel.Json.Test/JsonConfigurationSourceTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using Microsoft.Framework.ConfigurationModel.Json;
 using Microsoft.Framework.ConfigurationModel.Test;
 using Newtonsoft.Json;
 using Xunit;

--- a/test/Microsoft.Framework.ConfigurationModel.Test/ConfigurationTest.cs
+++ b/test/Microsoft.Framework.ConfigurationModel.Test/ConfigurationTest.cs
@@ -53,9 +53,9 @@ namespace Microsoft.Framework.ConfigurationModel.Test
             bool memRet1, memRet2, memRet3;
 
             // Act
-            config.AddLoadedSource(memConfigSrc1);
-            config.AddLoadedSource(memConfigSrc2);
-            config.AddLoadedSource(memConfigSrc3);
+            config.Add(memConfigSrc1, load: false);
+            config.Add(memConfigSrc2, load: false);
+            config.Add(memConfigSrc3, load: false);
 
             memRet1 = config.TryGet("mem1:keyinmem1", out memVal1);
             memRet2 = config.TryGet("Mem2:KeyInMem2", out memVal2);
@@ -103,8 +103,8 @@ namespace Microsoft.Framework.ConfigurationModel.Test
             var config = new Configuration();
 
             // Act
-            config.AddLoadedSource(memConfigSrc1);
-            config.AddLoadedSource(memConfigSrc2);
+            config.Add(memConfigSrc1, load: false);
+            config.Add(memConfigSrc2, load: false);
 
             // Assert
             Assert.Equal("ValueInMem2", config.Get("Key1:Key2"));
@@ -124,9 +124,9 @@ namespace Microsoft.Framework.ConfigurationModel.Test
             var memConfigSrc3 = new MemoryConfigurationSource(dict);
 
             var config = new Configuration();
-            config.AddLoadedSource(memConfigSrc1);
-            config.AddLoadedSource(memConfigSrc2);
-            config.AddLoadedSource(memConfigSrc3);
+            config.Add(memConfigSrc1, load: false);
+            config.Add(memConfigSrc2, load: false);
+            config.Add(memConfigSrc3, load: false);
 
             // Act
             config.Set("Key1", "NewValue1");
@@ -165,9 +165,9 @@ namespace Microsoft.Framework.ConfigurationModel.Test
             var memConfigSrc3 = new MemoryConfigurationSource(dic3);
 
             var config = new Configuration();
-            config.AddLoadedSource(memConfigSrc1);
-            config.AddLoadedSource(memConfigSrc2);
-            config.AddLoadedSource(memConfigSrc3);
+            config.Add(memConfigSrc1, load: false);
+            config.Add(memConfigSrc2, load: false);
+            config.Add(memConfigSrc3, load: false);
 
             string memVal1, memVal2, memVal3, memVal4, memVal5;
             bool memRet1, memRet2, memRet3, memRet4, memRet5;
@@ -227,9 +227,9 @@ namespace Microsoft.Framework.ConfigurationModel.Test
             var memConfigSrc3 = new MemoryConfigurationSource(dic3);
 
             var config = new Configuration();
-            config.AddLoadedSource(memConfigSrc1);
-            config.AddLoadedSource(memConfigSrc2);
-            config.AddLoadedSource(memConfigSrc3);
+            config.Add(memConfigSrc1, load: false);
+            config.Add(memConfigSrc2, load: false);
+            config.Add(memConfigSrc3, load: false);
 
             // Act
             var configFocusList = config.GetSubKeys("Data");
@@ -266,9 +266,9 @@ namespace Microsoft.Framework.ConfigurationModel.Test
             var config = new Configuration();
 
             // Act
-            config.AddLoadedSource(memConfigSrc1);
-            config.AddLoadedSource(memConfigSrc2);
-            config.AddLoadedSource(memConfigSrc3);
+            config.Add(memConfigSrc1, load: false);
+            config.Add(memConfigSrc2, load: false);
+            config.Add(memConfigSrc3, load: false);
 
             // Assert
             var enumerator = config.Sources.GetEnumerator();
@@ -304,9 +304,9 @@ namespace Microsoft.Framework.ConfigurationModel.Test
             var config = new Configuration();
 
             // Act
-            config.AddLoadedSource(memConfigSrc1);
-            config.AddLoadedSource(memConfigSrc2);
-            config.AddLoadedSource(memConfigSrc3);
+            config.Add(memConfigSrc1, load: false);
+            config.Add(memConfigSrc2, load: false);
+            config.Add(memConfigSrc3, load: false);
 
             var enumerable = config as IEnumerable;
 


### PR DESCRIPTION
@Eilon, in response to your comment [here](https://github.com/aspnet/Configuration/pull/186):

> IVT is to be used only for the unit test assembly of this assembly. Make the type(s) in question public and move to a  .Internal  namespace.

Couldn't move to an internal namespace because it is just a method. Also, moving it to an extension method would be strange because this method needs access to private fields. 