### PR TITLE
fix #197: Find a better name for IConfiguration.GetSubKey()

### DIFF
--- a/src/Microsoft.Framework.ConfigurationModel.Abstractions/IConfiguration.cs
+++ b/src/Microsoft.Framework.ConfigurationModel.Abstractions/IConfiguration.cs
@@ -18,11 +18,11 @@ namespace Microsoft.Framework.ConfigurationModel
 
         bool TryGet(string key, out string value);
 
-        IConfiguration GetSubKey(string key);
+        IConfiguration GetConfigurationSection(string key);
 
-        IEnumerable<KeyValuePair<string, IConfiguration>> GetSubKeys();
+        IEnumerable<KeyValuePair<string, IConfiguration>> GetConfigurationSections();
 
-        IEnumerable<KeyValuePair<string, IConfiguration>> GetSubKeys(string key);
+        IEnumerable<KeyValuePair<string, IConfiguration>> GetConfigurationSections(string key);
 
         void Set(string key, string value);
     }

--- a/src/Microsoft.Framework.ConfigurationModel.Abstractions/IConfigurationSource.cs
+++ b/src/Microsoft.Framework.ConfigurationModel.Abstractions/IConfigurationSource.cs
@@ -13,6 +13,9 @@ namespace Microsoft.Framework.ConfigurationModel
 
         void Load();
 
-        IEnumerable<string> ProduceSubKeys(IEnumerable<string> earlierKeys, string prefix, string delimiter);
+        IEnumerable<string> ProduceConfigurationSections(
+            IEnumerable<string> earlierKeys,
+            string prefix,
+            string delimiter);
     }
 }

--- a/src/Microsoft.Framework.ConfigurationModel/Configuration.cs
+++ b/src/Microsoft.Framework.ConfigurationModel/Configuration.cs
@@ -95,26 +95,26 @@ namespace Microsoft.Framework.ConfigurationModel
             }
         }
 
-        public IConfiguration GetSubKey(string key)
+        public IConfiguration GetConfigurationSection(string key)
         {
             return new ConfigurationFocus(this, key + Constants.KeyDelimiter);
         }
 
-        public IEnumerable<KeyValuePair<string, IConfiguration>> GetSubKeys()
+        public IEnumerable<KeyValuePair<string, IConfiguration>> GetConfigurationSections()
         {
-            return GetSubKeysImplementation(string.Empty);
+            return GetConfigurationSectionsImplementation(string.Empty);
         }
 
-        public IEnumerable<KeyValuePair<string, IConfiguration>> GetSubKeys([NotNull] string key)
+        public IEnumerable<KeyValuePair<string, IConfiguration>> GetConfigurationSections([NotNull] string key)
         {
-            return GetSubKeysImplementation(key + Constants.KeyDelimiter);
+            return GetConfigurationSectionsImplementation(key + Constants.KeyDelimiter);
         }
 
-        private IEnumerable<KeyValuePair<string, IConfiguration>> GetSubKeysImplementation(string prefix)
+        private IEnumerable<KeyValuePair<string, IConfiguration>> GetConfigurationSectionsImplementation(string prefix)
         {
             var segments = _sources.Aggregate(
                 Enumerable.Empty<string>(),
-                (seed, source) => source.ProduceSubKeys(seed, prefix, Constants.KeyDelimiter));
+                (seed, source) => source.ProduceConfigurationSections(seed, prefix, Constants.KeyDelimiter));
 
             var distinctSegments = segments.Distinct();
 
@@ -142,7 +142,8 @@ namespace Microsoft.Framework.ConfigurationModel
         /// Adds a new configuration source.
         /// </summary>
         /// <param name="configurationSource">The configuration source to add.</param>
-        /// <param name="load">If true, the configuration source's <see cref="IConfigurationSource.Load"/> method will be called.</param>
+        /// <param name="load">If true, the configuration source's <see cref="IConfigurationSource.Load"/> method will
+       ///  be called.</param>
         /// <returns>The same configuration source.</returns>
         /// <remarks>This method is intended only for test scenarios.</remarks>
         public IConfigurationSourceRoot Add(IConfigurationSource configurationSource, bool load)

--- a/src/Microsoft.Framework.ConfigurationModel/Internal/ConfigurationFocus.cs
+++ b/src/Microsoft.Framework.ConfigurationModel/Internal/ConfigurationFocus.cs
@@ -53,9 +53,9 @@ namespace Microsoft.Framework.ConfigurationModel.Internal
             return _root.TryGet(_prefix + key, out value);
         }
 
-        public IConfiguration GetSubKey(string key)
+        public IConfiguration GetConfigurationSection(string key)
         {
-            return _root.GetSubKey(_prefix + key);
+            return _root.GetConfigurationSection(_prefix + key);
         }
 
         public void Set(string key, string value)
@@ -63,14 +63,14 @@ namespace Microsoft.Framework.ConfigurationModel.Internal
             _root.Set(_prefix + key, value);
         }
 
-        public IEnumerable<KeyValuePair<string, IConfiguration>> GetSubKeys()
+        public IEnumerable<KeyValuePair<string, IConfiguration>> GetConfigurationSections()
         {
-            return _root.GetSubKeys(_prefix.Substring(0, _prefix.Length - 1));
+            return _root.GetConfigurationSections(_prefix.Substring(0, _prefix.Length - 1));
         }
 
-        public IEnumerable<KeyValuePair<string, IConfiguration>> GetSubKeys(string key)
+        public IEnumerable<KeyValuePair<string, IConfiguration>> GetConfigurationSections(string key)
         {
-            return _root.GetSubKeys(_prefix + key);
+            return _root.GetConfigurationSections(_prefix + key);
         }
     }
 }

--- a/src/Microsoft.Framework.ConfigurationModel/Sources/ConfigurationSource.cs
+++ b/src/Microsoft.Framework.ConfigurationModel/Sources/ConfigurationSource.cs
@@ -30,7 +30,10 @@ namespace Microsoft.Framework.ConfigurationModel
         {
         }
        
-        public virtual IEnumerable<string> ProduceSubKeys(IEnumerable<string> earlierKeys, string prefix, string delimiter)
+        public virtual IEnumerable<string> ProduceConfigurationSections(
+            IEnumerable<string> earlierKeys,
+            string prefix,
+            string delimiter)
         {
             return Data
                 .Where(kv => kv.Key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))

--- a/test/Microsoft.Framework.ConfigurationModel.FunctionalTests/ArrayTests.cs
+++ b/test/Microsoft.Framework.ConfigurationModel.FunctionalTests/ArrayTests.cs
@@ -56,18 +56,18 @@ i=ini_i.i.i.i
             config.AddJsonFile(_json2ConfigFilePath);
             config.AddXmlFile(_xmlConfigFilePath);
 
-            var subkey = config.GetSubKey("address");
-            var indexSubkeys = subkey.GetSubKeys().ToArray();
+            var configurationSection = config.GetConfigurationSection("address");
+            var indexConfigurationSections = configurationSection.GetConfigurationSections().ToArray();
 
-            Assert.Equal(8, indexSubkeys.Length);
-            Assert.Equal("0", indexSubkeys[0].Key);
-            Assert.Equal("1", indexSubkeys[1].Key);
-            Assert.Equal("2", indexSubkeys[2].Key);
-            Assert.Equal("3", indexSubkeys[3].Key);
-            Assert.Equal("4", indexSubkeys[4].Key);
-            Assert.Equal("i", indexSubkeys[5].Key);
-            Assert.Equal("j", indexSubkeys[6].Key);
-            Assert.Equal("x", indexSubkeys[7].Key);
+            Assert.Equal(8, indexConfigurationSections.Length);
+            Assert.Equal("0", indexConfigurationSections[0].Key);
+            Assert.Equal("1", indexConfigurationSections[1].Key);
+            Assert.Equal("2", indexConfigurationSections[2].Key);
+            Assert.Equal("3", indexConfigurationSections[3].Key);
+            Assert.Equal("4", indexConfigurationSections[4].Key);
+            Assert.Equal("i", indexConfigurationSections[5].Key);
+            Assert.Equal("j", indexConfigurationSections[6].Key);
+            Assert.Equal("x", indexConfigurationSections[7].Key);
         }
 
         [Fact]

--- a/test/Microsoft.Framework.ConfigurationModel.Json.Test/ArrayTest.cs
+++ b/test/Microsoft.Framework.ConfigurationModel.Json.Test/ArrayTest.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Framework.ConfigurationModel.Json.Test
             config.Add(jsonConfigSource1, load: false);
             config.Add(jsonConfigSource2, load: false);
 
-            Assert.Equal(3, config.GetSubKeys("ip").Count());
+            Assert.Equal(3, config.GetConfigurationSections("ip").Count());
             Assert.Equal("15.16.17.18", config.Get("ip:0"));
             Assert.Equal("7.8.9.10", config.Get("ip:1"));
             Assert.Equal("11.12.13.14", config.Get("ip:2"));
@@ -138,7 +138,7 @@ namespace Microsoft.Framework.ConfigurationModel.Json.Test
             config.Add(jsonConfigSource1, load: false);
             config.Add(jsonConfigSource2, load: false);
 
-            Assert.Equal(3, config.GetSubKeys("ip").Count());
+            Assert.Equal(3, config.GetConfigurationSections("ip").Count());
             Assert.Equal("1.2.3.4", config.Get("ip:0"));
             Assert.Equal("15.16.17.18", config.Get("ip:1"));
             Assert.Equal("11.12.13.14", config.Get("ip:2"));
@@ -171,7 +171,7 @@ namespace Microsoft.Framework.ConfigurationModel.Json.Test
             config.Add(jsonConfigSource1, load: false);
             config.Add(jsonConfigSource2, load: false);
 
-            Assert.Equal(4, config.GetSubKeys("ip").Count());
+            Assert.Equal(4, config.GetConfigurationSections("ip").Count());
             Assert.Equal("1.2.3.4", config.Get("ip:0"));
             Assert.Equal("7.8.9.10", config.Get("ip:1"));
             Assert.Equal("11.12.13.14", config.Get("ip:2"));
@@ -195,13 +195,13 @@ namespace Microsoft.Framework.ConfigurationModel.Json.Test
             var config = new Configuration();
             config.Add(jsonConfigSource, load: false);
 
-            var subkey = config.GetSubKey("setting");
-            var indexSubkeys = subkey.GetSubKeys().ToArray();
+            var configurationSection = config.GetConfigurationSection("setting");
+            var indexConfigurationSections = configurationSection.GetConfigurationSections().ToArray();
 
-            Assert.Equal(3, indexSubkeys.Count());
-            Assert.Equal("b", indexSubkeys[0].Value.Get(null));
-            Assert.Equal("a", indexSubkeys[1].Value.Get(null));
-            Assert.Equal("2", indexSubkeys[2].Value.Get(null));
+            Assert.Equal(3, indexConfigurationSections.Count());
+            Assert.Equal("b", indexConfigurationSections[0].Value.Get(null));
+            Assert.Equal("a", indexConfigurationSections[1].Value.Get(null));
+            Assert.Equal("2", indexConfigurationSections[2].Value.Get(null));
         }
 
         [Fact]
@@ -224,16 +224,16 @@ namespace Microsoft.Framework.ConfigurationModel.Json.Test
             var config = new Configuration();
             config.Add(jsonConfigSource, load: false);
 
-            var subkey = config.GetSubKey("setting");
-            var indexSubkeys = subkey.GetSubKeys().ToArray();
+            var configurationSection = config.GetConfigurationSection("setting");
+            var indexConfigurationSections = configurationSection.GetConfigurationSections().ToArray();
 
-            Assert.Equal(6, indexSubkeys.Count());
-            Assert.Equal("4", indexSubkeys[0].Key);
-            Assert.Equal("10", indexSubkeys[1].Key);
-            Assert.Equal("42", indexSubkeys[2].Key);
-            Assert.Equal("1text", indexSubkeys[3].Key);
-            Assert.Equal("bob", indexSubkeys[4].Key);
-            Assert.Equal("hello", indexSubkeys[5].Key);
+            Assert.Equal(6, indexConfigurationSections.Count());
+            Assert.Equal("4", indexConfigurationSections[0].Key);
+            Assert.Equal("10", indexConfigurationSections[1].Key);
+            Assert.Equal("42", indexConfigurationSections[2].Key);
+            Assert.Equal("1text", indexConfigurationSections[3].Key);
+            Assert.Equal("bob", indexConfigurationSections[4].Key);
+            Assert.Equal("hello", indexConfigurationSections[5].Key);
         }
     }
 }

--- a/test/Microsoft.Framework.ConfigurationModel.Test/ConfigurationHelperTest.cs
+++ b/test/Microsoft.Framework.ConfigurationModel.Test/ConfigurationHelperTest.cs
@@ -85,17 +85,17 @@ namespace Microsoft.Framework.ConfigurationModel.Test
                 throw new NotImplementedException();
             }
 
-            public IConfiguration GetSubKey(string key)
+            public IConfiguration GetConfigurationSection(string key)
             {
                 throw new NotImplementedException();
             }
 
-            public IEnumerable<KeyValuePair<string, IConfiguration>> GetSubKeys()
+            public IEnumerable<KeyValuePair<string, IConfiguration>> GetConfigurationSections()
             {
                 throw new NotImplementedException();
             }
 
-            public IEnumerable<KeyValuePair<string, IConfiguration>> GetSubKeys(string key)
+            public IEnumerable<KeyValuePair<string, IConfiguration>> GetConfigurationSections(string key)
             {
                 throw new NotImplementedException();
             }

--- a/test/Microsoft.Framework.ConfigurationModel.Test/ConfigurationTest.cs
+++ b/test/Microsoft.Framework.ConfigurationModel.Test/ConfigurationTest.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Framework.ConfigurationModel.Test
         }
 
         [Fact]
-        public void CanGetSubKey()
+        public void CanGetConfigurationSection()
         {
             // Arrange
             var dic1 = new Dictionary<string, string>()
@@ -173,7 +173,7 @@ namespace Microsoft.Framework.ConfigurationModel.Test
             bool memRet1, memRet2, memRet3, memRet4, memRet5;
 
             // Act
-            var configFocus = config.GetSubKey("Data");
+            var configFocus = config.GetConfigurationSection("Data");
 
             memRet1 = configFocus.TryGet("DB1:Connection1", out memVal1);
             memRet2 = configFocus.TryGet("DB1:Connection2", out memVal2);
@@ -206,7 +206,7 @@ namespace Microsoft.Framework.ConfigurationModel.Test
         }
 
         [Fact]
-        public void CanGetSubKeys()
+        public void CanGetConfigurationSections()
         {
             // Arrange
             var dic1 = new Dictionary<string, string>()
@@ -232,16 +232,16 @@ namespace Microsoft.Framework.ConfigurationModel.Test
             config.Add(memConfigSrc3, load: false);
 
             // Act
-            var configFocusList = config.GetSubKeys("Data");
-            var subKeysSet = configFocusList.ToDictionary(e => e.Key, e => e.Value);
+            var configFocusList = config.GetConfigurationSections("Data");
+            var configurationSectionsSet = configFocusList.ToDictionary(e => e.Key, e => e.Value);
 
             // Assert
             Assert.Equal(2, configFocusList.Count());
-            Assert.Equal("MemVal1", subKeysSet["DB1"].Get("Connection1"));
-            Assert.Equal("MemVal2", subKeysSet["DB1"].Get("Connection2"));
-            Assert.Equal("MemVal3", subKeysSet["DB2Connection"].Get(null));
-            Assert.False(subKeysSet.ContainsKey("DB3"));
-            Assert.False(subKeysSet.ContainsKey("Source:DB3"));
+            Assert.Equal("MemVal1", configurationSectionsSet["DB1"].Get("Connection1"));
+            Assert.Equal("MemVal2", configurationSectionsSet["DB1"].Get("Connection2"));
+            Assert.Equal("MemVal3", configurationSectionsSet["DB2Connection"].Get(null));
+            Assert.False(configurationSectionsSet.ContainsKey("DB3"));
+            Assert.False(configurationSectionsSet.ContainsKey("Source:DB3"));
         }
 
         [Fact]


### PR DESCRIPTION
@muratg, @troydai 

I built `Universe` repo with these changes and it build successfully.