### PR TITLE
Move ConfigurationBinder to Configuration

### DIFF
--- a/src/Microsoft.Framework.ConfigurationModel/ConfigurationBinder.cs
+++ b/src/Microsoft.Framework.ConfigurationModel/ConfigurationBinder.cs
@@ -1,0 +1,255 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Framework.Internal;
+
+namespace Microsoft.Framework.ConfigurationModel
+{
+    public static class ConfigurationBinder
+    {
+        public static TModel Bind<TModel>(IConfiguration configuration) where TModel : new()
+        {
+            var model = new TModel();
+            Bind(model, configuration);
+            return model;
+        }
+
+        public static void Bind(object model, IConfiguration configuration)
+        {
+            if (model == null)
+            {
+                return;
+            }
+
+            BindObjectProperties(model, configuration);
+        }
+
+        private static void BindObjectProperties(object obj, IConfiguration configuration)
+        {
+            foreach (var property in GetAllProperties(obj.GetType().GetTypeInfo()))
+            {
+                BindProperty(property, obj, configuration);
+            }
+        }
+
+        private static void BindProperty(PropertyInfo property, object propertyOwner, IConfiguration configuration)
+        {
+            configuration = configuration.GetConfigurationSection(property.Name);
+
+            if (property.GetMethod == null || !property.GetMethod.IsPublic)
+            {
+                // We don't support set only properties
+                return;
+            }
+
+            var propertyValue = property.GetValue(propertyOwner);
+            var hasPublicSetter = property.SetMethod != null && property.SetMethod.IsPublic;
+
+            if (propertyValue == null && !hasPublicSetter)
+            {
+                // Property doesn't have a value and we cannot set it so there is no
+                // point in going further down the graph
+                return;
+            }
+
+            propertyValue = BindType(
+                property.PropertyType,
+                propertyValue,
+                configuration);
+
+            if (propertyValue != null && hasPublicSetter)
+            {
+                property.SetValue(propertyOwner, propertyValue);
+            }
+        }
+
+        private static object BindType(Type type, object typeInstance, IConfiguration configuration)
+        {
+            var configValue = configuration.Get(null);
+            var typeInfo = type.GetTypeInfo();
+
+            if (configValue != null)
+            {
+                // Leaf nodes are always reinitialized
+                return CreateValueFromConfiguration(type, configValue, configuration);
+            }
+            else
+            {
+                var subkeys = configuration.GetConfigurationSections();
+                if (subkeys.Count() != 0)
+                {
+                    if (typeInstance == null)
+                    {
+                        if (typeInfo.IsInterface || typeInfo.IsAbstract)
+                        {
+                            throw new InvalidOperationException(Resources.FormatError_CannotActivateAbstractOrInterface(type));
+                        }
+
+                        bool hasParameterlessConstructor = typeInfo.DeclaredConstructors.Any(ctor => ctor.IsPublic && ctor.GetParameters().Length == 0);
+                        if (!hasParameterlessConstructor)
+                        {
+                            throw new InvalidOperationException(Resources.FormatError_MissingParameterlessConstructor(type));
+                        }
+
+                        try
+                        {
+                            typeInstance = Activator.CreateInstance(type);
+                        }
+                        catch (Exception ex)
+                        {
+                            throw new InvalidOperationException(Resources.FormatError_FailedToActivate(type), ex);
+                        }
+                    }
+
+                    var collectionInterface = GetGenericOpenInterfaceImplementation(typeof(IDictionary<,>), type);
+                    if (collectionInterface != null)
+                    {
+                        // Dictionary
+                        BindDictionary(typeInstance, collectionInterface, configuration);
+                    }
+                    else
+                    {
+                        collectionInterface = GetGenericOpenInterfaceImplementation(typeof(ICollection<>), type);
+                        if (collectionInterface != null)
+                        {
+                            // ICollection
+                            BindCollection(typeInstance, collectionInterface, configuration);
+                        }
+                        else
+                        {
+                            // Something else
+                            BindObjectProperties(typeInstance, configuration);
+                        }
+                    }
+                }
+                return typeInstance;
+            }
+        }
+
+        private static void BindDictionary(object dictionary, Type iDictionaryType, IConfiguration configuration)
+        {
+            var iDictionaryTypeInfo = iDictionaryType.GetTypeInfo();
+
+            // It is guaranteed to have a two and only two parameters
+            // because this is an IDictionary<K,V>
+            var keyType = iDictionaryTypeInfo.GenericTypeArguments[0];
+            var valueType = iDictionaryTypeInfo.GenericTypeArguments[1];
+
+            if (keyType != typeof(string))
+            {
+                // We only support string keys
+                return;
+            }
+
+            var addMethod = iDictionaryTypeInfo.GetDeclaredMethod("Add");
+            var subkeys = configuration.GetConfigurationSections().ToList();
+
+            foreach (var keyProperty in subkeys)
+            {
+                var keyConfiguration = keyProperty.Value;
+
+                var item = BindType(
+                    type: valueType,
+                    typeInstance: null,
+                    configuration: keyConfiguration);
+                if (item != null)
+                {
+                    addMethod.Invoke(dictionary, new[] { keyProperty.Key, item });
+                }
+            }
+        }
+
+        private static void BindCollection(object collection, Type iCollectionType, IConfiguration configuration)
+        {
+            var iCollectionTypeInfo = iCollectionType.GetTypeInfo();
+
+            // It is guaranteed to have a one and only one parameter
+            // because this is an ICollection<T>
+            var itemType = iCollectionTypeInfo.GenericTypeArguments[0];
+
+            var addMethod = iCollectionTypeInfo.GetDeclaredMethod("Add");
+            var subkeys = configuration.GetConfigurationSections().ToList();
+
+            foreach (var keyProperty in subkeys)
+            {
+                var keyConfiguration = keyProperty.Value;
+
+                try
+                {
+                    var item = BindType(
+                        type: itemType,
+                        typeInstance: null,
+                        configuration: keyConfiguration);
+                    if (item != null)
+                    {
+                        addMethod.Invoke(collection, new[] { item });
+                    }
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        private static object CreateValueFromConfiguration(Type type, string value, IConfiguration configuration)
+        {
+            var typeInfo = type.GetTypeInfo();
+
+            if (typeInfo.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
+            {
+                return CreateValueFromConfiguration(Nullable.GetUnderlyingType(type), value, configuration);
+            }
+
+            var configurationValue = configuration.Get(key: null);
+
+            try
+            {
+                if (typeInfo.IsEnum)
+                {
+                    return Enum.Parse(type, configurationValue);
+                }
+                else
+                {
+                    return Convert.ChangeType(configurationValue, type);
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException(Resources.FormatError_FailedBinding(configurationValue, type), ex);
+            }
+        }
+
+        private static Type GetGenericOpenInterfaceImplementation(Type expectedOpenGeneric, Type actual)
+        {
+            var interfaces = actual.GetTypeInfo().ImplementedInterfaces;
+            foreach (var interfaceType in interfaces)
+            {
+                if (interfaceType.GetTypeInfo().IsGenericType &&
+                    interfaceType.GetGenericTypeDefinition() == expectedOpenGeneric)
+                {
+                    return interfaceType;
+                }
+            }
+
+            return null;
+        }
+
+        private static IEnumerable<PropertyInfo> GetAllProperties(TypeInfo type)
+        {
+            var allProperties = new List<PropertyInfo>();
+
+            do
+            {
+                allProperties.AddRange(type.DeclaredProperties);
+                type = type.BaseType.GetTypeInfo();
+            }
+            while (type != typeof(object).GetTypeInfo());
+
+            return allProperties;
+        }
+    }
+}

--- a/src/Microsoft.Framework.ConfigurationModel/Properties/Resources.Designer.cs
+++ b/src/Microsoft.Framework.ConfigurationModel/Properties/Resources.Designer.cs
@@ -59,6 +59,54 @@ namespace Microsoft.Framework.ConfigurationModel
         }
 
         /// <summary>
+        /// Cannot create instance of type '{0}' because it is either abstract or an interface.
+        /// </summary>
+        internal static string Error_CannotActivateAbstractOrInterface
+        {
+            get { return GetString("Error_CannotActivateAbstractOrInterface"); }
+        }
+
+        /// <summary>
+        /// Cannot create instance of type '{0}' because it is either abstract or an interface.
+        /// </summary>
+        internal static string FormatError_CannotActivateAbstractOrInterface(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("Error_CannotActivateAbstractOrInterface"), p0);
+        }
+
+        /// <summary>
+        /// Failed to convert '{0}' to type '{1}'.
+        /// </summary>
+        internal static string Error_FailedBinding
+        {
+            get { return GetString("Error_FailedBinding"); }
+        }
+
+        /// <summary>
+        /// Failed to convert '{0}' to type '{1}'.
+        /// </summary>
+        internal static string FormatError_FailedBinding(object p0, object p1)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("Error_FailedBinding"), p0, p1);
+        }
+
+        /// <summary>
+        /// Failed to create instance of type '{0}'.
+        /// </summary>
+        internal static string Error_FailedToActivate
+        {
+            get { return GetString("Error_FailedToActivate"); }
+        }
+
+        /// <summary>
+        /// Failed to create instance of type '{0}'.
+        /// </summary>
+        internal static string FormatError_FailedToActivate(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("Error_FailedToActivate"), p0);
+        }
+
+        /// <summary>
         /// The configuration file '{0}' was not found and is not optional.
         /// </summary>
         internal static string Error_FileNotFound
@@ -136,6 +184,22 @@ namespace Microsoft.Framework.ConfigurationModel
         internal static string FormatError_MissingBasePath(object p0, object p1, object p2)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("Error_MissingBasePath"), p0, p1, p2);
+        }
+
+        /// <summary>
+        /// Cannot create instance of type '{0}' because it is missing a public parameterless constructor.
+        /// </summary>
+        internal static string Error_MissingParameterlessConstructor
+        {
+            get { return GetString("Error_MissingParameterlessConstructor"); }
+        }
+
+        /// <summary>
+        /// Cannot create instance of type '{0}' because it is missing a public parameterless constructor.
+        /// </summary>
+        internal static string FormatError_MissingParameterlessConstructor(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("Error_MissingParameterlessConstructor"), p0);
         }
 
         /// <summary>

--- a/src/Microsoft.Framework.ConfigurationModel/Resources.resx
+++ b/src/Microsoft.Framework.ConfigurationModel/Resources.resx
@@ -126,6 +126,15 @@
   <data name="Error_DuplicatedKeyInSwitchMappings" xml:space="preserve">
     <value>Keys in switch mappings are case-insensitive. A duplicated key '{0}' was found.</value>
   </data>
+  <data name="Error_CannotActivateAbstractOrInterface" xml:space="preserve">
+    <value>Cannot create instance of type '{0}' because it is either abstract or an interface.</value>
+  </data>
+  <data name="Error_FailedBinding" xml:space="preserve">
+    <value>Failed to convert '{0}' to type '{1}'.</value>
+  </data>
+  <data name="Error_FailedToActivate" xml:space="preserve">
+    <value>Failed to create instance of type '{0}'.</value>
+  </data>
   <data name="Error_FileNotFound" xml:space="preserve">
     <value>The configuration file '{0}' was not found and is not optional.</value>
   </data>
@@ -140,6 +149,9 @@
   </data>
   <data name="Error_MissingBasePath" xml:space="preserve">
     <value>Unable to resolve path '{0}'; construct this {1} with a non-null {2}.</value>
+  </data>
+  <data name="Error_MissingParameterlessConstructor" xml:space="preserve">
+    <value>Cannot create instance of type '{0}' because it is missing a public parameterless constructor.</value>
   </data>
   <data name="Error_NoCommitableSource" xml:space="preserve">
     <value>No registered configuration source is capable of committing changes.</value>

--- a/test/Microsoft.Framework.ConfigurationModel.Test/ConfigurationBinderExceptionTests.cs
+++ b/test/Microsoft.Framework.ConfigurationModel.Test/ConfigurationBinderExceptionTests.cs
@@ -1,0 +1,143 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Microsoft.Framework.ConfigurationModel.Test
+{
+    public class ConfigurationBinderExceptionTests
+    {
+        [Fact]
+        public void ExceptionWhenTryingToBindToInterface()
+        {
+            var input = new Dictionary<string, string>
+            {
+                {"ISomeInterfaceProperty:Subkey", "x"}
+            };
+
+            var config = new Configuration(new MemoryConfigurationSource(input));
+
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => ConfigurationBinder.Bind<TestOptions>(config));
+            Assert.Equal(
+                Resources.FormatError_CannotActivateAbstractOrInterface(typeof(ISomeInterface)),
+                exception.Message);
+        }
+
+        [Fact]
+        public void ExceptionWhenTryingToBindClassWithoutParameterlessConstructor()
+        {
+            var input = new Dictionary<string, string>
+            {
+                {"ClassWithoutPublicConstructorProperty:Subkey", "x"}
+            };
+
+            var config = new Configuration(new MemoryConfigurationSource(input));
+
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => ConfigurationBinder.Bind<TestOptions>(config));
+            Assert.Equal(
+                Resources.FormatError_MissingParameterlessConstructor(typeof(ClassWithoutPublicConstructor)),
+                exception.Message);
+        }
+
+        [Fact]
+        public void ExceptionWhenTryingToBindToTypeThatCannotBeConverted()
+        {
+            const string IncorrectValue = "This is not an int";
+
+            var input = new Dictionary<string, string>
+            {
+                {"IntProperty", IncorrectValue}
+            };
+
+            var config = new Configuration(new MemoryConfigurationSource(input));
+
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => ConfigurationBinder.Bind<TestOptions>(config));
+            Assert.NotNull(exception.InnerException);
+            Assert.Equal(
+                Resources.FormatError_FailedBinding(IncorrectValue, typeof(int)),
+                exception.Message);
+        }
+
+        [Fact]
+        public void ExceptionWhenTryingToBindToTypeThrowsWhenActivated()
+        {
+            var input = new Dictionary<string, string>
+            {
+                {"ThrowsWhenActivatedProperty:subkey", "x"}
+            };
+
+            var config = new Configuration(new MemoryConfigurationSource(input));
+
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => ConfigurationBinder.Bind<TestOptions>(config));
+            Assert.NotNull(exception.InnerException);
+            Assert.Equal(
+                Resources.FormatError_FailedToActivate(typeof(ThrowsWhenActivated)),
+                exception.Message);
+        }
+
+        [Fact]
+        public void ExceptionIncludesKeyOfFailedBinding()
+        {
+            var input = new Dictionary<string, string>
+            {
+                {"NestedOptionsProperty:NestedOptions2Property:ISomeInterfaceProperty:subkey", "x"}
+            };
+
+            var config = new Configuration(new MemoryConfigurationSource(input));
+
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => ConfigurationBinder.Bind<TestOptions>(config));
+            Assert.Equal(
+                Resources.FormatError_CannotActivateAbstractOrInterface(typeof(ISomeInterface)),
+                exception.Message);
+        }
+
+        private interface ISomeInterface
+        {
+        }
+
+        private class ClassWithoutPublicConstructor
+        {
+            private ClassWithoutPublicConstructor()
+            {
+            }
+        }
+
+        private class ThrowsWhenActivated
+        {
+            public ThrowsWhenActivated()
+            {
+                throw new Exception();
+            }
+        }
+
+        private class NestedOptions
+        {
+            public NestedOptions2 NestedOptions2Property { get; set; }
+        }
+
+        private class NestedOptions2
+        {
+            public ISomeInterface ISomeInterfaceProperty { get; set; }
+        }
+
+        private class TestOptions
+        {
+            public ISomeInterface ISomeInterfaceProperty { get; set; }
+
+            public ClassWithoutPublicConstructor ClassWithoutPublicConstructorProperty { get; set; }
+
+            public int IntProperty { get; set; }
+
+            public ThrowsWhenActivated ThrowsWhenActivatedProperty { get; set; }
+
+            public NestedOptions NestedOptionsProperty { get; set; }
+        }
+    }
+}

--- a/test/Microsoft.Framework.ConfigurationModel.Test/ConfigurationCollectionBindingTests.cs
+++ b/test/Microsoft.Framework.ConfigurationModel.Test/ConfigurationCollectionBindingTests.cs
@@ -1,0 +1,352 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Microsoft.Framework.ConfigurationModel.Test
+{
+    public class ConfigurationCollectionBinding
+    {
+        [Fact]
+        public void StringListBinding()
+        {
+            var input = new Dictionary<string, string>
+            {
+                {"StringList:0", "val0"},
+                {"StringList:1", "val1"},
+                {"StringList:2", "val2"},
+                {"StringList:x", "valx"}
+            };
+
+            var config = new Configuration(new MemoryConfigurationSource(input));
+
+            var options = ConfigurationBinder.Bind<OptionsWithLists>(config);
+
+            var list = options.StringList;
+
+            Assert.Equal(4, list.Count);
+
+            Assert.Equal("val0", list[0]);
+            Assert.Equal("val1", list[1]);
+            Assert.Equal("val2", list[2]);
+            Assert.Equal("valx", list[3]);
+        }
+
+        [Fact]
+        public void IntListBinding()
+        {
+            var input = new Dictionary<string, string>
+            {
+                {"IntList:0", "42"},
+                {"IntList:1", "43"},
+                {"IntList:2", "44"},
+                {"IntList:x", "45"}
+            };
+
+            var config = new Configuration(new MemoryConfigurationSource(input));
+
+            var options = ConfigurationBinder.Bind<OptionsWithLists>(config);
+
+            var list = options.IntList;
+
+            Assert.Equal(4, list.Count);
+
+            Assert.Equal(42, list[0]);
+            Assert.Equal(43, list[1]);
+            Assert.Equal(44, list[2]);
+            Assert.Equal(45, list[3]);
+        }
+
+        [Fact]
+        public void AlreadyInitializedListBinding()
+        {
+            var input = new Dictionary<string, string>
+            {
+                {"AlreadyInitializedList:0", "val0"},
+                {"AlreadyInitializedList:1", "val1"},
+                {"AlreadyInitializedList:2", "val2"},
+                {"AlreadyInitializedList:x", "valx"}
+            };
+
+            var config = new Configuration(new MemoryConfigurationSource(input));
+
+            var options = ConfigurationBinder.Bind<OptionsWithLists>(config);
+
+            var list = options.AlreadyInitializedList;
+
+            Assert.Equal(5, list.Count);
+
+            Assert.Equal("This was here before", list[0]);
+            Assert.Equal("val0", list[1]);
+            Assert.Equal("val1", list[2]);
+            Assert.Equal("val2", list[3]);
+            Assert.Equal("valx", list[4]);
+        }
+
+        [Fact]
+        public void CustomListBinding()
+        {
+            var input = new Dictionary<string, string>
+            {
+                {"CustomList:0", "val0"},
+                {"CustomList:1", "val1"},
+                {"CustomList:2", "val2"},
+                {"CustomList:x", "valx"}
+            };
+
+            var config = new Configuration(new MemoryConfigurationSource(input));
+
+            var options = ConfigurationBinder.Bind<OptionsWithLists>(config);
+
+            var list = options.CustomList;
+
+            Assert.Equal(4, list.Count);
+
+            Assert.Equal("val0", list[0]);
+            Assert.Equal("val1", list[1]);
+            Assert.Equal("val2", list[2]);
+            Assert.Equal("valx", list[3]);
+        }
+
+        [Fact]
+        public void ObjectListBinding()
+        {
+            var input = new Dictionary<string, string>
+            {
+                {"ObjectList:0:Integer", "30"},
+                {"ObjectList:1:Integer", "31"},
+                {"ObjectList:2:Integer", "32"},
+            };
+
+            var config = new Configuration(new MemoryConfigurationSource(input));
+
+            var options = ConfigurationBinder.Bind<OptionsWithLists>(config);
+
+            Assert.Equal(3, options.ObjectList.Count);
+
+            Assert.Equal(30, options.ObjectList[0].Integer);
+            Assert.Equal(31, options.ObjectList[1].Integer);
+            Assert.Equal(32, options.ObjectList[2].Integer);
+        }
+
+        [Fact]
+        public void NestedListsBinding()
+        {
+            var input = new Dictionary<string, string>
+            {
+                {"NestedLists:0:0", "val00"},
+                {"NestedLists:0:1", "val01"},
+                {"NestedLists:1:0", "val10"},
+                {"NestedLists:1:1", "val11"},
+                {"NestedLists:1:2", "val12"},
+            };
+
+            var config = new Configuration(new MemoryConfigurationSource(input));
+
+            var options = ConfigurationBinder.Bind<OptionsWithLists>(config);
+
+            Assert.Equal(2, options.NestedLists.Count);
+            Assert.Equal(2, options.NestedLists[0].Count);
+            Assert.Equal(3, options.NestedLists[1].Count);
+
+            Assert.Equal("val00", options.NestedLists[0][0]);
+            Assert.Equal("val01", options.NestedLists[0][1]);
+            Assert.Equal("val10", options.NestedLists[1][0]);
+            Assert.Equal("val11", options.NestedLists[1][1]);
+            Assert.Equal("val12", options.NestedLists[1][2]);
+        }
+
+        [Fact]
+        public void StringDictionaryBinding()
+        {
+            var input = new Dictionary<string, string>
+            {
+                {"StringDictionary:abc", "val_1"},
+                {"StringDictionary:def", "val_2"},
+                {"StringDictionary:ghi", "val_3"}
+            };
+
+            var config = new Configuration(new MemoryConfigurationSource(input));
+
+            var options = ConfigurationBinder.Bind<OptionsWithDictionary>(config);
+
+            Assert.Equal(3, options.StringDictionary.Count);
+
+            Assert.Equal("val_1", options.StringDictionary["abc"]);
+            Assert.Equal("val_2", options.StringDictionary["def"]);
+            Assert.Equal("val_3", options.StringDictionary["ghi"]);
+        }
+
+        [Fact]
+        public void IntDictionaryBinding()
+        {
+            var input = new Dictionary<string, string>
+            {
+                {"IntDictionary:abc", "42"},
+                {"IntDictionary:def", "43"},
+                {"IntDictionary:ghi", "44"}
+            };
+
+            var config = new Configuration(new MemoryConfigurationSource(input));
+
+            var options = ConfigurationBinder.Bind<OptionsWithDictionary>(config);
+
+            Assert.Equal(3, options.IntDictionary.Count);
+
+            Assert.Equal(42, options.IntDictionary["abc"]);
+            Assert.Equal(43, options.IntDictionary["def"]);
+            Assert.Equal(44, options.IntDictionary["ghi"]);
+        }
+
+        [Fact]
+        public void ObjectDictionary()
+        {
+            var input = new Dictionary<string, string>
+            {
+                {"ObjectDictionary:abc:Integer", "1"},
+                {"ObjectDictionary:def:Integer", "2"},
+                {"ObjectDictionary:ghi:Integer", "3"}
+            };
+
+            var config = new Configuration(new MemoryConfigurationSource(input));
+
+            var options = ConfigurationBinder.Bind<OptionsWithDictionary>(config);
+
+            Assert.Equal(3, options.ObjectDictionary.Count);
+
+            Assert.Equal(1, options.ObjectDictionary["abc"].Integer);
+            Assert.Equal(2, options.ObjectDictionary["def"].Integer);
+            Assert.Equal(3, options.ObjectDictionary["ghi"].Integer);
+        }
+
+        [Fact]
+        public void ListDictionary()
+        {
+            var input = new Dictionary<string, string>
+            {
+                {"ListDictionary:abc:0", "abc_0"},
+                {"ListDictionary:abc:1", "abc_1"},
+                {"ListDictionary:def:0", "def_0"},
+                {"ListDictionary:def:1", "def_1"},
+                {"ListDictionary:def:2", "def_2"}
+            };
+
+            var config = new Configuration(new MemoryConfigurationSource(input));
+
+            var options = ConfigurationBinder.Bind<OptionsWithDictionary>(config);
+
+            Assert.Equal(2, options.ListDictionary.Count);
+            Assert.Equal(2, options.ListDictionary["abc"].Count);
+            Assert.Equal(3, options.ListDictionary["def"].Count);
+
+            Assert.Equal("abc_0", options.ListDictionary["abc"][0]);
+            Assert.Equal("abc_1", options.ListDictionary["abc"][1]);
+            Assert.Equal("def_0", options.ListDictionary["def"][0]);
+            Assert.Equal("def_1", options.ListDictionary["def"][1]);
+            Assert.Equal("def_2", options.ListDictionary["def"][2]);
+        }
+
+        [Fact]
+        public void ListInNestedOptionBinding()
+        {
+            var input = new Dictionary<string, string>
+            {
+                {"ObjectList:0:ListInNestedOption:0", "00"},
+                {"ObjectList:0:ListInNestedOption:1", "01"},
+                {"ObjectList:1:ListInNestedOption:0", "10"},
+                {"ObjectList:1:ListInNestedOption:1", "11"},
+                {"ObjectList:1:ListInNestedOption:2", "12"},
+            };
+
+            var config = new Configuration(new MemoryConfigurationSource(input));
+
+            var options = ConfigurationBinder.Bind<OptionsWithLists>(config);
+
+            Assert.Equal(2, options.ObjectList.Count);
+            Assert.Equal(2, options.ObjectList[0].ListInNestedOption.Count);
+            Assert.Equal(3, options.ObjectList[1].ListInNestedOption.Count);
+
+            Assert.Equal("00", options.ObjectList[0].ListInNestedOption[0]);
+            Assert.Equal("01", options.ObjectList[0].ListInNestedOption[1]);
+            Assert.Equal("10", options.ObjectList[1].ListInNestedOption[0]);
+            Assert.Equal("11", options.ObjectList[1].ListInNestedOption[1]);
+            Assert.Equal("12", options.ObjectList[1].ListInNestedOption[2]);
+        }
+
+        [Fact]
+        public void NonStringKeyDictionaryBinding()
+        {
+            var input = new Dictionary<string, string>
+            {
+                {"NonStringKeyDictionary:abc", "val_1"},
+                {"NonStringKeyDictionary:def", "val_2"},
+                {"NonStringKeyDictionary:ghi", "val_3"}
+            };
+
+            var config = new Configuration(new MemoryConfigurationSource(input));
+
+            var options = ConfigurationBinder.Bind<OptionsWithDictionary>(config);
+
+            Assert.Equal(0, options.NonStringKeyDictionary.Count);
+        }
+
+        private class CustomList : List<string>
+        {
+            // Add an overload, just to make sure binding picks the right Add method
+            public void Add(string a, string b)
+            {
+            }
+        }
+
+        private class CustomDictionary<T> : Dictionary<string, T>
+        {
+        }
+
+        private class NestedOptions
+        {
+            public int Integer { get; set; }
+
+            public List<string> ListInNestedOption { get; set; }
+        }
+
+        private class OptionsWithLists
+        {
+            public OptionsWithLists()
+            {
+                AlreadyInitializedList = new List<string>();
+                AlreadyInitializedList.Add("This was here before");
+            }
+
+            public CustomList CustomList { get; set; }
+
+            public List<string> StringList { get; set; }
+
+            public List<int> IntList { get; set; }
+
+            // This cannot be initialized because we cannot
+            // activate an interface
+            public IList<string> StringListInterface { get; set; }
+
+            public List<List<string>> NestedLists { get; set; }
+
+            public List<string> AlreadyInitializedList { get; set; }
+
+            public List<NestedOptions> ObjectList { get; set; }
+        }
+
+        private class OptionsWithDictionary
+        {
+            public Dictionary<string, int> IntDictionary { get; set; }
+
+            public Dictionary<string, string> StringDictionary { get; set; }
+
+            public Dictionary<string, NestedOptions> ObjectDictionary { get; set; }
+
+            public Dictionary<string, List<string>> ListDictionary { get; set; }
+
+            public Dictionary<NestedOptions, string> NonStringKeyDictionary { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Per @divega discussions with core configuration/options moving to BCL, the ConfigurationBinder was going to move to asp.net specific configuration.  While only the DI specific options helpers will remain in  Options repo, which will still depend on Configuration for the configure services sugar that uses the binder: `services.Configure<MyOptions>(config)`

The binder could live in ConfigurationModel.Abstractions if we were willing to make depend on reflection and add the error resources... 

cc @victorhurdugaci I renamed TOptions => TModel since this is really a generic POCO binder anyways, there's nothing specific to options about the binder anyways...
