### PR TITLE
Allow environment variables with the same name but in different cases

### DIFF
--- a/src/Microsoft.Framework.Configuration.EnvironmentVariables/EnvironmentVariablesConfigurationSource.cs
+++ b/src/Microsoft.Framework.Configuration.EnvironmentVariables/EnvironmentVariablesConfigurationSource.cs
@@ -37,14 +37,18 @@ namespace Microsoft.Framework.Configuration.EnvironmentVariables
 
         internal void Load(IDictionary envVariables)
         {
-            Data = envVariables
+            Data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            var filteredEnvVariables = envVariables
                 .Cast<DictionaryEntry>()
                 .SelectMany(AzureEnvToAppEnv)
-                .Where(entry => ((string)entry.Key).StartsWith(_prefix, StringComparison.OrdinalIgnoreCase))
-                .ToDictionary(
-                    entry => ((string)entry.Key).Substring(_prefix.Length),
-                    entry => (string)entry.Value,
-                    StringComparer.Ordinal);
+                .Where(entry => ((string)entry.Key).StartsWith(_prefix, StringComparison.OrdinalIgnoreCase));
+
+            foreach (var envVariable in filteredEnvVariables)
+            {
+                var key = ((string)envVariable.Key).Substring(_prefix.Length);
+                Data[key] = (string)envVariable.Value;
+            }
         }
 
         private static IEnumerable<DictionaryEntry> AzureEnvToAppEnv(DictionaryEntry entry)

--- a/src/Microsoft.Framework.Configuration.EnvironmentVariables/EnvironmentVariablesConfigurationSource.cs
+++ b/src/Microsoft.Framework.Configuration.EnvironmentVariables/EnvironmentVariablesConfigurationSource.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Framework.Configuration.EnvironmentVariables
                 .ToDictionary(
                     entry => ((string)entry.Key).Substring(_prefix.Length),
                     entry => (string)entry.Value,
-                    StringComparer.OrdinalIgnoreCase);
+                    StringComparer.Ordinal);
         }
 
         private static IEnumerable<DictionaryEntry> AzureEnvToAppEnv(DictionaryEntry entry)

--- a/test/Microsoft.Framework.Configuration.EnvironmentVariables.Test/EnvironmentVariablesConfigurationSourceTest.cs
+++ b/test/Microsoft.Framework.Configuration.EnvironmentVariables.Test/EnvironmentVariablesConfigurationSourceTest.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Framework.Configuration.EnvironmentVariables.Test
         }
 
         [Fact]
-        public void ThrowExceptionWhenKeyIsDuplicatedInAzureEnvironment()
+        public void LastVariableAddedWhenKeyIsDuplicatedInAzureEnvironment()
         {
             var dict = new Hashtable()
                 {
@@ -111,13 +111,27 @@ namespace Microsoft.Framework.Configuration.EnvironmentVariables.Test
                 };
             var envConfigSrc = new EnvironmentVariablesConfigurationSource();
 
-            // On mono the exception message is different 
-            var isMono = Type.GetType("Mono.Runtime") != null; 
-            var expectedMsg = isMono ? "An element with the same key already exists in the dictionary." : "An item with the same key has already been added.";
+            envConfigSrc.Load(dict);
 
-            var exception = Assert.Throws<ArgumentException>(() => envConfigSrc.Load(dict));
+            Assert.True(!string.IsNullOrEmpty(envConfigSrc.Get("Data:db2:ConnectionString")));
+            Assert.Equal("System.Data.SqlClient", envConfigSrc.Get("Data:db2:ProviderName"));
+        }
 
-            Assert.Equal(expectedMsg, exception.Message);
+        [Fact]
+        public void LastVariableAddedWhenMultipleEnvironmentVariablesWithSameNameButDifferentCaseExist()
+        {
+            var dict = new Hashtable()
+                {
+                    {"CommonEnv", "CommonEnvValue1"},
+                    {"commonenv", "commonenvValue2"},
+                    {"cOMMonEnv", "commonenvValue3"},
+                };
+            var envConfigSrc = new EnvironmentVariablesConfigurationSource();
+
+            envConfigSrc.Load(dict);
+
+            Assert.True(!string.IsNullOrEmpty(envConfigSrc.Get("cOMMonEnv")));
+            Assert.True(!string.IsNullOrEmpty(envConfigSrc.Get("CommonEnv")));
         }
     }
 }


### PR DESCRIPTION
Exception in case of two environment variables with the same name but in different case fixed. As discussed with @Eilon in pull request #224, "last key wins" algorithm has been implemented.