### PR TITLE
Adding support for TimeSpan and DateTimeOffset to ConfigurationBinder

### DIFF
--- a/src/Microsoft.Framework.Configuration.Binder/ConfigurationBinder.cs
+++ b/src/Microsoft.Framework.Configuration.Binder/ConfigurationBinder.cs
@@ -213,11 +213,11 @@ namespace Microsoft.Framework.Configuration
                 {
                     return Enum.Parse(type, configurationValue);
                 }
-                else if(type == typeof(TimeSpan))
+                else if (type == typeof(TimeSpan))
                 {
                     return TimeSpan.Parse(configurationValue, CultureInfo.InvariantCulture);
                 }
-                else if(type == typeof(DateTimeOffset))
+                else if (type == typeof(DateTimeOffset))
                 {
                     return DateTimeOffset.Parse(configurationValue, CultureInfo.InvariantCulture);
                 }

--- a/src/Microsoft.Framework.Configuration.Binder/ConfigurationBinder.cs
+++ b/src/Microsoft.Framework.Configuration.Binder/ConfigurationBinder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Framework.Configuration.Binder;
@@ -211,6 +212,14 @@ namespace Microsoft.Framework.Configuration
                 if (typeInfo.IsEnum)
                 {
                     return Enum.Parse(type, configurationValue);
+                }
+                else if(type == typeof(TimeSpan))
+                {
+                    return TimeSpan.Parse(configurationValue, CultureInfo.InvariantCulture);
+                }
+                else if(type == typeof(DateTimeOffset))
+                {
+                    return DateTimeOffset.Parse(configurationValue, CultureInfo.InvariantCulture);
                 }
                 else
                 {

--- a/test/Microsoft.Framework.Configuration.Binder.Test/ConfigurationCollectionBindingTests.cs
+++ b/test/Microsoft.Framework.Configuration.Binder.Test/ConfigurationCollectionBindingTests.cs
@@ -165,6 +165,37 @@ namespace Microsoft.Framework.Configuration.Binder.Test
         }
 
         [Fact]
+        public void TimeSpanListBinding()
+        {
+            var timeSpans = new TimeSpan[]
+            {
+                new TimeSpan(356, 23, 59, 59, 999),
+                new TimeSpan(2, 1, 3),
+                new TimeSpan(12, 34, 56)
+            };
+
+            var input = new Dictionary<string, string>
+            {
+                {"TimeSpanList:0", timeSpans[0].ToString()},
+                {"TimeSpanList:1", timeSpans[1].ToString()},
+                {"TimeSpanList:2", timeSpans[2].ToString()}
+            };
+
+            var builder = new ConfigurationBuilder(new MemoryConfigurationSource(input));
+            var config = builder.Build();
+
+            var options = ConfigurationBinder.Bind<OptionsWithLists>(config);
+
+            var list = options.TimeSpanList;
+
+            Assert.Equal(3, list.Count);
+
+            Assert.Equal(timeSpans[0], list[0]);
+            Assert.Equal(timeSpans[1], list[1]);
+            Assert.Equal(timeSpans[2], list[2]);
+        }
+
+        [Fact]
         public void StringDictionaryBinding()
         {
             var input = new Dictionary<string, string>
@@ -346,6 +377,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
             public List<string> AlreadyInitializedList { get; set; }
 
             public List<NestedOptions> ObjectList { get; set; }
+
+            public List<TimeSpan> TimeSpanList { get; set; }
         }
 
         private class OptionsWithDictionary

--- a/test/Microsoft.Framework.Configuration.Binder.Test/project.json
+++ b/test/Microsoft.Framework.Configuration.Binder.Test/project.json
@@ -1,8 +1,8 @@
-{
+﻿{
   "dependencies": {
+    "Microsoft.AspNet.Testing": "1.0.0-*",
     "Microsoft.Framework.Configuration.Binder": "1.0.0-*",
     "Microsoft.Framework.Configuration.Test.Common": "1.0.0-*",
-    "Microsoft.AspNet.Testing": "1.0.0-*",
     "xunit.runner.aspnet": "2.0.0-aspnet-*"
   },
   "frameworks": {
@@ -13,4 +13,3 @@
     "test": "xunit.runner.aspnet"
   }
 }
-

--- a/test/Microsoft.Framework.Configuration.Binder.Test/project.json
+++ b/test/Microsoft.Framework.Configuration.Binder.Test/project.json
@@ -1,7 +1,8 @@
-﻿{
+{
   "dependencies": {
     "Microsoft.Framework.Configuration.Binder": "1.0.0-*",
     "Microsoft.Framework.Configuration.Test.Common": "1.0.0-*",
+    "Microsoft.AspNet.Testing": "1.0.0-*",
     "xunit.runner.aspnet": "2.0.0-aspnet-*"
   },
   "frameworks": {
@@ -12,3 +13,4 @@
     "test": "xunit.runner.aspnet"
   }
 }
+

--- a/test/Microsoft.Framework.Configuration.Xml.Test/XmlConfigurationSourceTest.cs
+++ b/test/Microsoft.Framework.Configuration.Xml.Test/XmlConfigurationSourceTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using Microsoft.AspNet.Testing;
 using Microsoft.Framework.Configuration.Test;
 using Xunit;
 
@@ -277,6 +278,7 @@ namespace Microsoft.Framework.Configuration.Xml.Test
         }
 
         [Fact]
+        [ReplaceCulture]
         public void ThrowExceptionWhenFindDTD()
         {
             var xml =


### PR DESCRIPTION
+ Modified ConfigurationBinder to support `TimeSpan` and `DateTimeOffset`. 
+ Added new unit tests for the changes
+ Fixed on test in `XmlConfigurationSourceTest.cs` to also work on non en-US systems

According to #216 

@davidfowl I rebuild the changes into a new pull request. Hope this time everything is good :pray: