### PR TITLE
fix #168: Can all constructors of XmlConfigurationSource be made public

### DIFF
--- a/src/Microsoft.Framework.Configuration.Xml/XmlConfigurationSource.cs
+++ b/src/Microsoft.Framework.Configuration.Xml/XmlConfigurationSource.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Framework.Configuration
         {
         }
 
-        internal XmlConfigurationSource(string path, bool optional)
+        public XmlConfigurationSource(string path, bool optional)
             : this(path, null, optional: optional)
         {
         }


### PR DESCRIPTION
Just made 1 constructor public. The other constructors take `XmlDocumentDecryptor` (which is `internal` class) as parameter.  So left them `internal`.

@muratg 