### PR TITLE
Fix Namespaces

### DIFF
--- a/src/Microsoft.Framework.Configuration.Json/JsonConfigurationSource.cs
+++ b/src/Microsoft.Framework.Configuration.Json/JsonConfigurationSource.cs
@@ -5,10 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Microsoft.Framework.Configuration.Json;
 using Newtonsoft.Json;
 
-namespace Microsoft.Framework.Configuration
+namespace Microsoft.Framework.Configuration.Json
 {
     /// <summary>
     /// A JSON file based <see cref="ConfigurationSource"/>.

--- a/src/Microsoft.Framework.Configuration.Xml/EncryptedXmlDocumentDecryptor.cs
+++ b/src/Microsoft.Framework.Configuration.Xml/EncryptedXmlDocumentDecryptor.cs
@@ -6,7 +6,7 @@ using System;
 using System.Security.Cryptography.Xml;
 using System.Xml;
 
-namespace Microsoft.Framework.Configuration
+namespace Microsoft.Framework.Configuration.Xml
 {
     /// <summary>
     /// A decryptor that uses the EncryptedXml class in the desktop CLR.

--- a/src/Microsoft.Framework.Configuration.Xml/XmlConfigurationSource.cs
+++ b/src/Microsoft.Framework.Configuration.Xml/XmlConfigurationSource.cs
@@ -6,9 +6,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml;
-using Microsoft.Framework.Configuration.Xml;
 
-namespace Microsoft.Framework.Configuration
+namespace Microsoft.Framework.Configuration.Xml
 {
     /// <summary>
     /// An XML file based <see cref="ConfigurationSource"/>.

--- a/src/Microsoft.Framework.Configuration.Xml/XmlDocumentDecryptor.cs
+++ b/src/Microsoft.Framework.Configuration.Xml/XmlDocumentDecryptor.cs
@@ -4,9 +4,8 @@
 using System;
 using System.IO;
 using System.Xml;
-using Microsoft.Framework.Configuration.Xml;
 
-namespace Microsoft.Framework.Configuration
+namespace Microsoft.Framework.Configuration.Xml
 {
     internal class XmlDocumentDecryptor
     {


### PR DESCRIPTION
I think it will be better if we update the namespace for ```JsonConfigurationSource``` to ```Microsoft.Framework.Configuration.Json``` instead of ```Microsoft.Framework.Configuration``` as also  ```Microsoft.Framework.Configuration.Xml``` instead of ```Microsoft.Framework.Configuration``` as well as other classes ```EncryptedXmlDocumentDecryptor``` and ```XmlDocumentDecryptor``` to ```Microsoft.Framework.Configuration.Xml```