### PR TITLE
ConfigurationBinder now uses System.ComponentModel.TypeConverter.

### DIFF
--- a/src/Microsoft.Framework.Configuration.Binder/ConfigurationBinder.cs
+++ b/src/Microsoft.Framework.Configuration.Binder/ConfigurationBinder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Framework.Configuration.Binder;
@@ -208,14 +209,7 @@ namespace Microsoft.Framework.Configuration
 
             try
             {
-                if (typeInfo.IsEnum)
-                {
-                    return Enum.Parse(type, configurationValue);
-                }
-                else
-                {
-                    return Convert.ChangeType(configurationValue, type);
-                }
+                return TypeDescriptor.GetConverter(type).ConvertFromInvariantString(configurationValue);
             }
             catch (Exception ex)
             {

--- a/src/Microsoft.Framework.Configuration.Binder/project.json
+++ b/src/Microsoft.Framework.Configuration.Binder/project.json
@@ -12,6 +12,10 @@
   "frameworks": {
     "net45": { },
     "dnx451": { },
-    "dotnet": { }
+    "dotnet": {
+      "dependencies": {
+        "System.ComponentModel.TypeConverter": "4.0.0-*"
+      }
+    }
   }
 }

--- a/test/Microsoft.Framework.Configuration.Binder.Test/ConfigurationBinderTests.cs
+++ b/test/Microsoft.Framework.Configuration.Binder.Test/ConfigurationBinderTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Reflection;
 using Xunit;
 
@@ -65,6 +66,95 @@ namespace Microsoft.Framework.Configuration.Binder.Test
             public UriKind UriKind { get; set; }
         }
 
+        public class GenericOptions<T>
+        {
+            public T Value { get; set; }
+        }
+
+        [Theory]
+        [InlineData("2147483647", typeof(int))]
+        [InlineData("4294967295", typeof(uint))]
+        [InlineData("32767", typeof(short))]
+        [InlineData("65535", typeof(ushort))]
+        [InlineData("-9223372036854775808", typeof(long))]
+        [InlineData("18446744073709551615", typeof(ulong))]
+        [InlineData("trUE", typeof(bool))]
+        [InlineData("255", typeof(byte))]
+        [InlineData("127", typeof(sbyte))]
+        [InlineData("\uffff", typeof(char))]
+        [InlineData("79228162514264337593543950335", typeof(decimal))]
+        [InlineData("1.79769e+308", typeof(double))]
+        [InlineData("3.40282347E+38", typeof(float))]
+        [InlineData("2015-12-24T07:34:42-5:00", typeof(DateTime))]
+        [InlineData("12/24/2015 13:44:55 +4", typeof(DateTimeOffset))]
+        [InlineData("99.22:22:22.1234567", typeof(TimeSpan))]
+        // enum test
+        [InlineData("Constructor", typeof(AttributeTargets))]
+        [InlineData("CA761232-ED42-11CE-BACD-00AA0057B223", typeof(Guid))]
+        public void CanReadAllSupportedTypes(string value, Type type)
+        {
+            // arrange
+            var dic = new Dictionary<string, string>
+            {
+                {"Value", value}
+            };
+            var builder = new ConfigurationBuilder(new MemoryConfigurationSource(dic));
+            var config = builder.Build();
+            var optionsType = typeof(GenericOptions<>).MakeGenericType(type);
+            var options = Activator.CreateInstance(optionsType);
+            var expectedValue = TypeDescriptor.GetConverter(type).ConvertFromInvariantString(value);
+
+            // act
+            ConfigurationBinder.Bind(options, config);            
+            var optionsValue = options.GetType().GetProperty("Value").GetValue(options);
+            
+            // assert            
+            Assert.Equal(expectedValue, optionsValue);
+        }
+
+        [Theory]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(uint))]
+        [InlineData(typeof(short))]
+        [InlineData(typeof(ushort))]
+        [InlineData(typeof(long))]
+        [InlineData(typeof(ulong))]
+        [InlineData(typeof(bool))]
+        [InlineData(typeof(byte))]
+        [InlineData(typeof(sbyte))]
+        [InlineData(typeof(char))]
+        [InlineData(typeof(decimal))]
+        [InlineData(typeof(double))]
+        [InlineData(typeof(float))]
+        [InlineData(typeof(DateTime))]
+        [InlineData(typeof(DateTimeOffset))]
+        [InlineData(typeof(TimeSpan))]
+        [InlineData(typeof(AttributeTargets))]
+        [InlineData(typeof(Guid))]
+        public void ConsistentExceptionOnFailedBinding(Type type)
+        {
+            // arrange
+            const string IncorrectValue = "Invalid data";
+            var dic = new Dictionary<string, string>
+            {
+                {"Value", IncorrectValue}
+            };
+            var builder = new ConfigurationBuilder(new MemoryConfigurationSource(dic));
+            var config = builder.Build();
+            var optionsType = typeof(GenericOptions<>).MakeGenericType(type);
+            var options = Activator.CreateInstance(optionsType);
+            
+            // act
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => ConfigurationBinder.Bind(options, config));
+
+            // assert
+            Assert.NotNull(exception.InnerException);
+            Assert.Equal(
+                Resources.FormatError_FailedBinding(IncorrectValue, type),
+                exception.Message);
+        }
+
         [Fact]
         public void CanReadComplexProperties()
         {
@@ -90,7 +180,7 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"Integer", "-2"},
                 {"Boolean", "TRUe"},
                 {"Nested:Integer", "11"},
-                {"Virtual","Sup"}
+                {"Virtual", "Sup"}
             };
             var builder = new ConfigurationBuilder(new MemoryConfigurationSource(dic));
             var config = builder.Build();
@@ -164,27 +254,6 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 () => ConfigurationBinder.Bind<TestOptions>(config));
             Assert.Equal(
                 Resources.FormatError_MissingParameterlessConstructor(typeof(ClassWithoutPublicConstructor)),
-                exception.Message);
-        }
-
-        [Fact]
-        public void ExceptionWhenTryingToBindToTypeThatCannotBeConverted()
-        {
-            const string IncorrectValue = "This is not an int";
-
-            var input = new Dictionary<string, string>
-            {
-                {"IntProperty", IncorrectValue}
-            };
-
-            var builder = new ConfigurationBuilder(new MemoryConfigurationSource(input));
-            var config = builder.Build();
-
-            var exception = Assert.Throws<InvalidOperationException>(
-                () => ConfigurationBinder.Bind<TestOptions>(config));
-            Assert.NotNull(exception.InnerException);
-            Assert.Equal(
-                Resources.FormatError_FailedBinding(IncorrectValue, typeof(int)),
                 exception.Message);
         }
 

--- a/test/Microsoft.Framework.Configuration.Xml.Test/XmlConfigurationSourceTest.cs
+++ b/test/Microsoft.Framework.Configuration.Xml.Test/XmlConfigurationSourceTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using Microsoft.AspNet.Testing;
 using Microsoft.Framework.Configuration.Test;
 using Xunit;
 
@@ -277,6 +278,7 @@ namespace Microsoft.Framework.Configuration.Xml.Test
         }
 
         [Fact]
+        [ReplaceCulture]
         public void ThrowExceptionWhenFindDTD()
         {
             var xml =


### PR DESCRIPTION
* Modified `ConfigurationBinder` to use `TypeConverter` instead of `Convert.ChangeType`.
* Added new unit tests for the changes
* Fixed one test in XmlConfigurationSourceTest.cs to also work on non en-US systems

#216

@Eilon @muratg @kirthik @HaoK, if you pick this solution I will close #228.