### PR TITLE
API review feedback for ConfigurationBinder

### DIFF
--- a/src/Microsoft.Framework.Configuration.Binder/ConfigurationBinder.cs
+++ b/src/Microsoft.Framework.Configuration.Binder/ConfigurationBinder.cs
@@ -23,17 +23,17 @@ namespace Microsoft.Framework.Configuration
             }
         }
 
-        private static void BindProperty(PropertyInfo property, object propertyOwner, IConfiguration configuration)
+        private static void BindProperty(PropertyInfo property, object instance, IConfiguration config)
         {
-            configuration = configuration.GetSection(property.Name);
-
-            if (property.GetMethod == null || !property.GetMethod.IsPublic || property.GetMethod.GetParameters().Length > 0)
+            // We don't support set only, non public, or indexer properties
+            if (property.GetMethod == null || 
+                !property.GetMethod.IsPublic || 
+                property.GetMethod.GetParameters().Length > 0)
             {
-                // We don't support set only properties or indexers
                 return;
             }
 
-            var propertyValue = property.GetValue(propertyOwner);
+            var propertyValue = property.GetValue(instance);
             var hasPublicSetter = property.SetMethod != null && property.SetMethod.IsPublic;
 
             if (propertyValue == null && !hasPublicSetter)
@@ -43,55 +43,43 @@ namespace Microsoft.Framework.Configuration
                 return;
             }
 
-            propertyValue = BindType(
-                property.PropertyType,
-                propertyValue,
-                configuration);
-
+            propertyValue = BindInstance(property.PropertyType, propertyValue, config.GetSection(property.Name));
             if (propertyValue != null && hasPublicSetter)
             {
-                property.SetValue(propertyOwner, propertyValue);
+                property.SetValue(instance, propertyValue);
             }
         }
 
-        private static object BindType(Type type, object typeInstance, IConfiguration configuration)
+        private static object BindInstance(Type type, object instance, IConfiguration config)
         {
-            string configValue = null;
-            IConfigurationSection configurationSection = null;
-
-            var typeInfo = type.GetTypeInfo();
-
-            if (configuration is IConfigurationSection)
-            {
-                configurationSection = (IConfigurationSection)configuration;
-                configValue = configurationSection.Value;
-            }
-
+            var section = config as IConfigurationSection;
+            var configValue = section?.Value;
             if (configValue != null)
             {
                 // Leaf nodes are always reinitialized
-                return CreateValueFromSection(type, configValue, configurationSection);
+                return ReadValue(type, configValue, section);
             }
             else
             {
-                if (configuration.GetChildren().Count() != 0)
+                if (config.GetChildren().Count() != 0)
                 {
-                    if (typeInstance == null)
+                    if (instance == null)
                     {
+                        var typeInfo = type.GetTypeInfo();
                         if (typeInfo.IsInterface || typeInfo.IsAbstract)
                         {
                             throw new InvalidOperationException(Resources.FormatError_CannotActivateAbstractOrInterface(type));
                         }
 
-                        bool hasParameterlessConstructor = typeInfo.DeclaredConstructors.Any(ctor => ctor.IsPublic && ctor.GetParameters().Length == 0);
-                        if (!hasParameterlessConstructor)
+                        var hasDefaultConstructor = typeInfo.DeclaredConstructors.Any(ctor => ctor.IsPublic && ctor.GetParameters().Length == 0);
+                        if (!hasDefaultConstructor)
                         {
                             throw new InvalidOperationException(Resources.FormatError_MissingParameterlessConstructor(type));
                         }
 
                         try
                         {
-                            typeInstance = Activator.CreateInstance(type);
+                            instance = Activator.CreateInstance(type);
                         }
                         catch (Exception ex)
                         {
@@ -99,37 +87,36 @@ namespace Microsoft.Framework.Configuration
                         }
                     }
 
-                    var collectionInterface = GetGenericOpenInterfaceImplementation(typeof(IDictionary<,>), type);
+                    // See if its a Dictionary
+                    var collectionInterface = FindOpenGenericInterface(typeof(IDictionary<,>), type);
                     if (collectionInterface != null)
                     {
-                        // Dictionary
-                        BindDictionary(typeInstance, collectionInterface, configuration);
+                        BindDictionary(instance, collectionInterface, config);
                     }
                     else
                     {
-                        collectionInterface = GetGenericOpenInterfaceImplementation(typeof(ICollection<>), type);
+                        // See if its an ICollection
+                        collectionInterface = FindOpenGenericInterface(typeof(ICollection<>), type);
                         if (collectionInterface != null)
                         {
-                            // ICollection
-                            BindCollection(typeInstance, collectionInterface, configuration);
+                            BindCollection(instance, collectionInterface, config);
                         }
+                        // Something else
                         else
                         {
-                            // Something else
-                            Bind(configuration, typeInstance);
+                            Bind(config, instance);
                         }
                     }
                 }
-                return typeInstance;
+                return instance;
             }
         }
 
-        private static void BindDictionary(object dictionary, Type dictionaryType, IConfiguration configuration)
+        private static void BindDictionary(object dictionary, Type dictionaryType, IConfiguration config)
         {
             var typeInfo = dictionaryType.GetTypeInfo();
 
-            // It is guaranteed to have a two and only two parameters
-            // because this is an IDictionary<K,V>
+            // IDictionary<K,V> is guaranteed to have exactly two parameters
             var keyType = typeInfo.GenericTypeArguments[0];
             var valueType = typeInfo.GenericTypeArguments[1];
 
@@ -140,19 +127,20 @@ namespace Microsoft.Framework.Configuration
             }
 
             var addMethod = typeInfo.GetDeclaredMethod("Add");
-            foreach (var configurationSection in configuration.GetChildren())
+            foreach (var child in config.GetChildren())
             {
-                var item = BindType(
+                var item = BindInstance(
                     type: valueType,
-                    typeInstance: null,
-                    configuration: configurationSection);
+                    instance: null,
+                    config: child);
                 if (item != null)
                 {
-                    var key = configurationSection.Key;
-                    if (configuration is IConfigurationSection)
+                    var key = child.Key;
+                    var section = config as IConfigurationSection;
+                    if (section != null)
                     {
                         // Remove the parent key and : delimiter to get the configurationSection's key
-                        key = key.Substring((configuration as IConfigurationSection).Key.Length + 1);
+                        key = key.Substring(section.Key.Length + 1);
                     }
 
                     addMethod.Invoke(dictionary, new[] { key, item });
@@ -160,22 +148,22 @@ namespace Microsoft.Framework.Configuration
             }
         }
 
-        private static void BindCollection(object collection, Type collectionType, IConfiguration configuration)
+        private static void BindCollection(object collection, Type collectionType, IConfiguration config)
         {
             var typeInfo = collectionType.GetTypeInfo();
 
-            // It is guaranteed to have a one and only one parameter
-            // because this is an ICollection<T>
+            // ICollection<T> is guaranteed to have exacly one parameter
             var itemType = typeInfo.GenericTypeArguments[0];
             var addMethod = typeInfo.GetDeclaredMethod("Add");
-            foreach (var configurationSection in configuration.GetChildren())
+
+            foreach (var section in config.GetChildren())
             {
                 try
                 {
-                    var item = BindType(
+                    var item = BindInstance(
                         type: itemType,
-                        typeInstance: null,
-                        configuration: configurationSection);
+                        instance: null,
+                        config: section);
                     if (item != null)
                     {
                         addMethod.Invoke(collection, new[] { item });
@@ -187,39 +175,34 @@ namespace Microsoft.Framework.Configuration
             }
         }
 
-        private static object CreateValueFromSection(Type type, string value, IConfigurationSection configuration)
+        private static object ReadValue(Type type, string value, IConfigurationSection config)
         {
-            var typeInfo = type.GetTypeInfo();
-
-            if (typeInfo.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
+            if (type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
             {
-                return CreateValueFromSection(Nullable.GetUnderlyingType(type), value, configuration);
+                return ReadValue(Nullable.GetUnderlyingType(type), value, config);
             }
-
-            var configurationValue = configuration.Value;
 
             try
             {
-                return TypeDescriptor.GetConverter(type).ConvertFromInvariantString(configurationValue);
+                return TypeDescriptor.GetConverter(type).ConvertFromInvariantString(config.Value);
             }
             catch (Exception ex)
             {
-                throw new InvalidOperationException(Resources.FormatError_FailedBinding(configurationValue, type), ex);
+                throw new InvalidOperationException(Resources.FormatError_FailedBinding(config.Value, type), ex);
             }
         }
 
-        private static Type GetGenericOpenInterfaceImplementation(Type expectedOpenGeneric, Type actual)
+        private static Type FindOpenGenericInterface(Type expected, Type actual)
         {
             var interfaces = actual.GetTypeInfo().ImplementedInterfaces;
             foreach (var interfaceType in interfaces)
             {
                 if (interfaceType.GetTypeInfo().IsGenericType &&
-                    interfaceType.GetGenericTypeDefinition() == expectedOpenGeneric)
+                    interfaceType.GetGenericTypeDefinition() == expected)
                 {
                     return interfaceType;
                 }
             }
-
             return null;
         }
 

--- a/test/Microsoft.Framework.Configuration.Binder.Test/ConfigurationBinderTests.cs
+++ b/test/Microsoft.Framework.Configuration.Binder.Test/ConfigurationBinderTests.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Framework.Configuration.Binder.Test
             var expectedValue = TypeDescriptor.GetConverter(type).ConvertFromInvariantString(value);
 
             // act
-            ConfigurationBinder.Bind(options, config);
+            config.Bind(options);
             var optionsValue = options.GetType().GetProperty("Value").GetValue(options);
             
             // assert            
@@ -150,7 +150,7 @@ namespace Microsoft.Framework.Configuration.Binder.Test
             
             // act
             var exception = Assert.Throws<InvalidOperationException>(
-                () => ConfigurationBinder.Bind(options, config));
+                () => config.Bind(options));
 
             // assert
             Assert.NotNull(exception.InnerException);
@@ -164,7 +164,7 @@ namespace Microsoft.Framework.Configuration.Binder.Test
         {
             var builder = new ConfigurationBuilder();
             var config = builder.Build();
-            Assert.NotNull(ConfigurationBinder.Bind<List<string>>(config));
+            config.Bind(new List<string>());
         }
 
         [Fact]
@@ -178,8 +178,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
             };
             var builder = new ConfigurationBuilder(new MemoryConfigurationSource(dic));
             var config = builder.Build();
-
-            var options = ConfigurationBinder.Bind<ComplexOptions>(config);
+            var options = new ComplexOptions();
+            config.Bind(options);
             Assert.True(options.Boolean);
             Assert.Equal(-2, options.Integer);
             Assert.Equal(11, options.Nested.Integer);
@@ -197,8 +197,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
             };
             var builder = new ConfigurationBuilder(new MemoryConfigurationSource(dic));
             var config = builder.Build();
-
-            var options = ConfigurationBinder.Bind<DerivedOptions>(config);
+            var options = new DerivedOptions();
+            config.Bind(options);
             Assert.True(options.Boolean);
             Assert.Equal(-2, options.Integer);
             Assert.Equal(11, options.Nested.Integer);
@@ -214,8 +214,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
             };
             var builder = new ConfigurationBuilder(new MemoryConfigurationSource(dic));
             var config = builder.Build();
-
-            var options = ConfigurationBinder.Bind<ComplexOptions>(config);
+            var options = new ComplexOptions();
+            config.Bind(options);
             Assert.Equal("stuff", ComplexOptions.StaticProperty);
         }
 
@@ -232,8 +232,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
             };
             var builder = new ConfigurationBuilder(new MemoryConfigurationSource(dic));
             var config = builder.Build();
-
-            var options = ConfigurationBinder.Bind<ComplexOptions>(config);
+            var options = new ComplexOptions();
+            config.Bind(options);
             Assert.Null(options.GetType().GetTypeInfo().GetDeclaredProperty(property).GetValue(options));
         }
 
@@ -249,7 +249,7 @@ namespace Microsoft.Framework.Configuration.Binder.Test
             var config = builder.Build();
 
             var exception = Assert.Throws<InvalidOperationException>(
-                () => ConfigurationBinder.Bind<TestOptions>(config));
+                () => config.Bind(new TestOptions()));
             Assert.Equal(
                 Resources.FormatError_CannotActivateAbstractOrInterface(typeof(ISomeInterface)),
                 exception.Message);
@@ -267,7 +267,7 @@ namespace Microsoft.Framework.Configuration.Binder.Test
             var config = builder.Build();
 
             var exception = Assert.Throws<InvalidOperationException>(
-                () => ConfigurationBinder.Bind<TestOptions>(config));
+                () => config.Bind(new TestOptions()));
             Assert.Equal(
                 Resources.FormatError_MissingParameterlessConstructor(typeof(ClassWithoutPublicConstructor)),
                 exception.Message);
@@ -285,7 +285,7 @@ namespace Microsoft.Framework.Configuration.Binder.Test
             var config = builder.Build();
 
             var exception = Assert.Throws<InvalidOperationException>(
-                () => ConfigurationBinder.Bind<TestOptions>(config));
+                () => config.Bind(new TestOptions()));
             Assert.NotNull(exception.InnerException);
             Assert.Equal(
                 Resources.FormatError_FailedToActivate(typeof(ThrowsWhenActivated)),
@@ -304,8 +304,7 @@ namespace Microsoft.Framework.Configuration.Binder.Test
             var config = builder.Build();
 
             var exception = Assert.Throws<InvalidOperationException>(
-                () => ConfigurationBinder.Bind<TestOptions>(config));
-
+                () => config.Bind(new TestOptions()));
             Assert.Equal(
                 Resources.FormatError_CannotActivateAbstractOrInterface(typeof(ISomeInterface)),
                 exception.Message);

--- a/test/Microsoft.Framework.Configuration.Binder.Test/ConfigurationCollectionBindingTests.cs
+++ b/test/Microsoft.Framework.Configuration.Binder.Test/ConfigurationCollectionBindingTests.cs
@@ -24,8 +24,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
 
             var builder = new ConfigurationBuilder(new MemoryConfigurationSource(input));
             var config = builder.Build();
-
-            var options = ConfigurationBinder.Bind<OptionsWithLists>(config);
+            var options = new OptionsWithLists();
+            config.Bind(options);
 
             var list = options.StringList;
 
@@ -51,7 +51,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
             var builder = new ConfigurationBuilder(new MemoryConfigurationSource(input));
             var config = builder.Build();
 
-            var options = ConfigurationBinder.Bind<OptionsWithLists>(config);
+            var options = new OptionsWithLists();
+            config.Bind(options);
 
             var list = options.IntList;
 
@@ -77,7 +78,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
             var builder = new ConfigurationBuilder(new MemoryConfigurationSource(input));
             var config = builder.Build();
 
-            var options = ConfigurationBinder.Bind<OptionsWithLists>(config);
+            var options = new OptionsWithLists();
+            config.Bind(options);
 
             var list = options.AlreadyInitializedList;
 
@@ -104,7 +106,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
             var builder = new ConfigurationBuilder(new MemoryConfigurationSource(input));
             var config = builder.Build();
 
-            var options = ConfigurationBinder.Bind<OptionsWithLists>(config);
+            var options = new OptionsWithLists();
+            config.Bind(options);
 
             var list = options.CustomList;
 
@@ -128,8 +131,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
 
             var builder = new ConfigurationBuilder(new MemoryConfigurationSource(input));
             var config = builder.Build();
-
-            var options = ConfigurationBinder.Bind<OptionsWithLists>(config);
+            var options = new OptionsWithLists();
+            config.Bind(options);
 
             Assert.Equal(3, options.ObjectList.Count);
 
@@ -152,8 +155,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
 
             var builder = new ConfigurationBuilder(new MemoryConfigurationSource(input));
             var config = builder.Build();
-
-            var options = ConfigurationBinder.Bind<OptionsWithLists>(config);
+            var options = new OptionsWithLists();
+            config.Bind(options);
 
             Assert.Equal(2, options.NestedLists.Count);
             Assert.Equal(2, options.NestedLists[0].Count);
@@ -178,8 +181,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
 
             var builder = new ConfigurationBuilder(new MemoryConfigurationSource(input));
             var config = builder.Build();
-
-            var options = ConfigurationBinder.Bind<OptionsWithDictionary>(config);
+            var options = new OptionsWithDictionary();
+            config.Bind(options);
 
             Assert.Equal(3, options.StringDictionary.Count);
 
@@ -200,8 +203,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
 
             var builder = new ConfigurationBuilder(new MemoryConfigurationSource(input));
             var config = builder.Build();
-
-            var options = ConfigurationBinder.Bind<OptionsWithDictionary>(config);
+            var options = new OptionsWithDictionary();
+            config.Bind(options);
 
             Assert.Equal(3, options.IntDictionary.Count);
 
@@ -222,8 +225,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
 
             var builder = new ConfigurationBuilder(new MemoryConfigurationSource(input));
             var config = builder.Build();
-
-            var options = ConfigurationBinder.Bind<OptionsWithDictionary>(config);
+            var options = new OptionsWithDictionary();
+            config.Bind(options);
 
             Assert.Equal(3, options.ObjectDictionary.Count);
 
@@ -246,8 +249,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
 
             var builder = new ConfigurationBuilder(new MemoryConfigurationSource(input));
             var config = builder.Build();
-
-            var options = ConfigurationBinder.Bind<OptionsWithDictionary>(config);
+            var options = new OptionsWithDictionary();
+            config.Bind(options);
 
             Assert.Equal(2, options.ListDictionary.Count);
             Assert.Equal(2, options.ListDictionary["abc"].Count);
@@ -274,8 +277,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
 
             var builder = new ConfigurationBuilder(new MemoryConfigurationSource(input));
             var config = builder.Build();
-
-            var options = ConfigurationBinder.Bind<OptionsWithLists>(config);
+            var options = new OptionsWithLists();
+            config.Bind(options);
 
             Assert.Equal(2, options.ObjectList.Count);
             Assert.Equal(2, options.ObjectList[0].ListInNestedOption.Count);
@@ -300,8 +303,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
 
             var builder = new ConfigurationBuilder(new MemoryConfigurationSource(input));
             var config = builder.Build();
-
-            var options = ConfigurationBinder.Bind<OptionsWithDictionary>(config);
+            var options = new OptionsWithDictionary();
+            config.Bind(options);
 
             Assert.Equal(0, options.NonStringKeyDictionary.Count);
         }


### PR DESCRIPTION
Fixes https://github.com/aspnet/Configuration/issues/236

I took the liberty to clean some stuff up and we don't actually need generics on bind since we don't care what the type is I don't think do we?  We are using reflection.  We only needed the Type when we were new'ing them up in the overload we killed.  Callee now is responsible

cc @divega @kirthik 