### PR TITLE
Adding support for arrays to ConfigurationBinder

### DIFF
--- a/src/Microsoft.Framework.Configuration.Binder/Properties/Resources.Designer.cs
+++ b/src/Microsoft.Framework.Configuration.Binder/Properties/Resources.Designer.cs
@@ -74,6 +74,22 @@ namespace Microsoft.Framework.Configuration.Binder
             return string.Format(CultureInfo.CurrentCulture, GetString("Error_MissingParameterlessConstructor"), p0);
         }
 
+        /// <summary>
+        /// Cannot create instance of type '{0}' because multidimensional arrays are not supported.
+        /// </summary>
+        internal static string Error_UnsupportedMultidimensionalArray
+        {
+            get { return GetString("Error_UnsupportedMultidimensionalArray"); }
+        }
+
+        /// <summary>
+        /// Cannot create instance of type '{0}' because multidimensional arrays are not supported.
+        /// </summary>
+        internal static string FormatError_UnsupportedMultidimensionalArray(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("Error_UnsupportedMultidimensionalArray"), p0);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.Framework.Configuration.Binder/Resources.resx
+++ b/src/Microsoft.Framework.Configuration.Binder/Resources.resx
@@ -129,4 +129,7 @@
   <data name="Error_MissingParameterlessConstructor" xml:space="preserve">
     <value>Cannot create instance of type '{0}' because it is missing a public parameterless constructor.</value>
   </data>
+  <data name="Error_UnsupportedMultidimensionalArray" xml:space="preserve">
+    <value>Cannot create instance of type '{0}' because multidimensional arrays are not supported.</value>
+  </data>
 </root>


### PR DESCRIPTION
Adding support for arrays in Configuration Binder.
- The implementation preserves already initialized arrays! And it also works for jagged arrays.
- Multidimensional arrays are not supported and `Bind` will throw an exception in that case.
- Added new unit tests
- Refactored the instance creation from `BindProperty` a little bit to make the code more readable

#268 