### PR TITLE
Code cleanup: Use configurationBuilder or builder as name of parameters of type IConfigurationBuilder

### DIFF
--- a/src/Microsoft.Framework.Configuration.CommandLine/CommandLineConfigurationExtensions.cs
+++ b/src/Microsoft.Framework.Configuration.CommandLine/CommandLineConfigurationExtensions.cs
@@ -8,19 +8,19 @@ namespace Microsoft.Framework.Configuration
 {
     public static class CommandLineConfigurationExtensions
     {
-        public static IConfigurationBuilder AddCommandLine(this IConfigurationBuilder configuration, string[] args)
+        public static IConfigurationBuilder AddCommandLine(this IConfigurationBuilder configurationBuilder, string[] args)
         {
-            configuration.Add(new CommandLineConfigurationProvider(args));
-            return configuration;
+            configurationBuilder.Add(new CommandLineConfigurationProvider(args));
+            return configurationBuilder;
         }
 
         public static IConfigurationBuilder AddCommandLine(
-            this IConfigurationBuilder configuration,
+            this IConfigurationBuilder configurationBuilder,
             string[] args,
             IDictionary<string, string> switchMappings)
         {
-            configuration.Add(new CommandLineConfigurationProvider(args, switchMappings));
-            return configuration;
+            configurationBuilder.Add(new CommandLineConfigurationProvider(args, switchMappings));
+            return configurationBuilder;
         }
     }
 }

--- a/src/Microsoft.Framework.Configuration.EnvironmentVariables/EnvironmentVariablesExtensions.cs
+++ b/src/Microsoft.Framework.Configuration.EnvironmentVariables/EnvironmentVariablesExtensions.cs
@@ -7,18 +7,18 @@ namespace Microsoft.Framework.Configuration
 {
     public static class EnvironmentVariablesExtensions
     {
-        public static IConfigurationBuilder AddEnvironmentVariables(this IConfigurationBuilder configuration)
+        public static IConfigurationBuilder AddEnvironmentVariables(this IConfigurationBuilder configurationBuilder)
         {
-            configuration.Add(new EnvironmentVariablesConfigurationProvider());
-            return configuration;
+            configurationBuilder.Add(new EnvironmentVariablesConfigurationProvider());
+            return configurationBuilder;
         }
 
         public static IConfigurationBuilder AddEnvironmentVariables(
-            this IConfigurationBuilder configuration,
+            this IConfigurationBuilder configurationBuilder,
             string prefix)
         {
-            configuration.Add(new EnvironmentVariablesConfigurationProvider(prefix));
-            return configuration;
+            configurationBuilder.Add(new EnvironmentVariablesConfigurationProvider(prefix));
+            return configurationBuilder;
         }
     }
 }

--- a/src/Microsoft.Framework.Configuration/MemoryConfigurationExtensions.cs
+++ b/src/Microsoft.Framework.Configuration/MemoryConfigurationExtensions.cs
@@ -12,36 +12,36 @@ namespace Microsoft.Framework.Configuration
         /// <summary>
         /// Adds the memory configuration provider to <paramref name="configuraton"/>.
         /// </summary>
-        /// <param name="configuration">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
-        public static IConfigurationBuilder AddInMemoryCollection(this IConfigurationBuilder configuration)
+        public static IConfigurationBuilder AddInMemoryCollection(this IConfigurationBuilder configurationBuilder)
         {
-            if (configuration == null)
+            if (configurationBuilder == null)
             {
-                throw new ArgumentNullException(nameof(configuration));
+                throw new ArgumentNullException(nameof(configurationBuilder));
             }
 
-            configuration.Add(new MemoryConfigurationProvider());
-            return configuration;
+            configurationBuilder.Add(new MemoryConfigurationProvider());
+            return configurationBuilder;
         }
 
         /// <summary>
         /// Adds the memory configuration provider to <paramref name="configuraton"/>.
         /// </summary>
-        /// <param name="configuration">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
         /// <param name="initialData">The data to add to memory configuration provider.</param>
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
         public static IConfigurationBuilder AddInMemoryCollection(
-            this IConfigurationBuilder configuration,
+            this IConfigurationBuilder configurationBuilder,
             IEnumerable<KeyValuePair<string, string>> initialData)
         {
-            if (configuration == null)
+            if (configurationBuilder == null)
             {
-                throw new ArgumentNullException(nameof(configuration));
+                throw new ArgumentNullException(nameof(configurationBuilder));
             }
 
-            configuration.Add(new MemoryConfigurationProvider(initialData));
-            return configuration;
+            configurationBuilder.Add(new MemoryConfigurationProvider(initialData));
+            return configurationBuilder;
         }
     }
 }

--- a/test/Microsoft.Framework.Configuration.Binder.Test/ConfigurationBinderTests.cs
+++ b/test/Microsoft.Framework.Configuration.Binder.Test/ConfigurationBinderTests.cs
@@ -82,8 +82,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"Boolean", "TRUe"},
                 {"Nested:Integer", "11"}
             };
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(dic));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(dic));
+            var config = configurationBuilder.Build();
 
             Assert.True(config.Get<bool?>("Boolean"));
             Assert.Equal(-2, config.Get<int?>("Integer"));
@@ -100,8 +100,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"Nested:Integer", null},
                 {"Object", null }
             };
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(dic));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(dic));
+            var config = configurationBuilder.Build();
 
             Assert.False(config.Get<bool>("Boolean"));
             Assert.Equal(0, config.Get<int>("Integer"));
@@ -115,8 +115,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
             var dic = new Dictionary<string, string>
             {
             };
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(dic));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(dic));
+            var config = configurationBuilder.Build();
 
             Assert.False(config.Get<bool>("Boolean"));
             Assert.Equal(0, config.Get<int>("Integer"));
@@ -132,8 +132,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
             {
                 {"AnUri", "http://www.bing.com"}
             };
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(dic));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(dic));
+            var config = configurationBuilder.Build();
 
             var uri = config.Get<Uri>("AnUri");
 
@@ -171,8 +171,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
             {
                 {"Value", value}
             };
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(dic));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(dic));
+            var config = configurationBuilder.Build();
 
             var optionsType = typeof(GenericOptions<>).MakeGenericType(type);
             var options = Activator.CreateInstance(optionsType);
@@ -215,8 +215,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
             {
                 {"Value", IncorrectValue}
             };
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(dic));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(dic));
+            var config = configurationBuilder.Build();
 
             var optionsType = typeof(GenericOptions<>).MakeGenericType(type);
             var options = Activator.CreateInstance(optionsType);
@@ -242,8 +242,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
         [Fact]
         public void BinderIgnoresIndexerProperties()
         {
-            var builder = new ConfigurationBuilder();
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder();
+            var config = configurationBuilder.Build();
             config.Bind(new List<string>());
         }
 
@@ -256,8 +256,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"Boolean", "TRUe"},
                 {"Nested:Integer", "11"}
             };
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(dic));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(dic));
+            var config = configurationBuilder.Build();
             
             var instance = new ComplexOptions();
             config.Bind(instance);
@@ -276,8 +276,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"Boolean", "TRUe"},
                 {"Nested:Integer", "11"}
             };
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(dic));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(dic));
+            var config = configurationBuilder.Build();
 
             var options = config.Get<ComplexOptions>();
 
@@ -296,8 +296,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"Nested:Integer", "11"},
                 {"Virtual", "Sup"}
             };
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(dic));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(dic));
+            var config = configurationBuilder.Build();
             
             var instance = new DerivedOptions();
             config.Bind(instance);
@@ -318,8 +318,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"Nested:Integer", "11"},
                 {"Virtual", "Sup"}
             };
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(dic));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(dic));
+            var config = configurationBuilder.Build();
 
             var options = config.Get<DerivedOptions>();
 
@@ -336,8 +336,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
             {
                 {"StaticProperty", "stuff"},
             };
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(dic));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(dic));
+            var config = configurationBuilder.Build();
 
             var options = config.Get<ComplexOptions>();
 
@@ -351,8 +351,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
             {
                 {"StaticProperty", "other stuff"},
             };
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(dic));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(dic));
+            var config = configurationBuilder.Build();
 
             var instance = new ComplexOptions();
             config.Bind(instance);
@@ -371,8 +371,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
             {
                 {property, "stuff"},
             };
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(dic));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(dic));
+            var config = configurationBuilder.Build();
 
             var options = config.Get<ComplexOptions>();
             Assert.Null(options.GetType().GetTypeInfo().GetDeclaredProperty(property).GetValue(options));
@@ -389,8 +389,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
             {
                 {property, "stuff"},
             };
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(dic));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(dic));
+            var config = configurationBuilder.Build();
 
             var options = new ComplexOptions();
             config.Bind(options);
@@ -406,8 +406,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"ISomeInterfaceProperty:Subkey", "x"}
             };
 
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
+            var config = configurationBuilder.Build();
 
             var exception = Assert.Throws<InvalidOperationException>(
                 () => config.Get<TestOptions>());
@@ -424,8 +424,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"ClassWithoutPublicConstructorProperty:Subkey", "x"}
             };
 
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
+            var config = configurationBuilder.Build();
 
             var exception = Assert.Throws<InvalidOperationException>(
                 () => config.Get<TestOptions>());
@@ -442,8 +442,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"ThrowsWhenActivatedProperty:subkey", "x"}
             };
 
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
+            var config = configurationBuilder.Build();
 
             var exception = Assert.Throws<InvalidOperationException>(
                 () => config.Get<TestOptions>());
@@ -461,8 +461,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"NestedOptionsProperty:NestedOptions2Property:ISomeInterfaceProperty:subkey", "x"}
             };
 
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
+            var config = configurationBuilder.Build();
 
             var exception = Assert.Throws<InvalidOperationException>(
                 () => config.Get<TestOptions>());

--- a/test/Microsoft.Framework.Configuration.Binder.Test/ConfigurationCollectionBindingTests.cs
+++ b/test/Microsoft.Framework.Configuration.Binder.Test/ConfigurationCollectionBindingTests.cs
@@ -22,8 +22,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"StringList:x", "valx"}
             };
 
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
+            var config = configurationBuilder.Build();
             var list = config.Get<List<string>>("StringList");
 
             Assert.Equal(4, list.Count);
@@ -45,8 +45,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"StringList:x", null}
             };
 
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
+            var config = configurationBuilder.Build();
             var list = config.Get<List<string>>("StringList");
 
             Assert.Equal(0, list.Count);
@@ -61,8 +61,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"InvalidList:1", "invalid"},
             };
 
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
+            var config = configurationBuilder.Build();
             var list = config.Get<List<bool>>("InvalidList");
 
             Assert.Equal(1, list.Count);
@@ -76,8 +76,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
             {
             };
 
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
+            var config = configurationBuilder.Build();
             var list = config.Get<List<string>>("StringList");
 
             Assert.Null(list);
@@ -94,8 +94,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"StringList:x", "valx"}
             };
 
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
+            var config = configurationBuilder.Build();
 
             var list = new List<string>();
             config.GetSection("StringList").Bind(list);
@@ -118,8 +118,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"ObjectList:2:Integer", "32"},
             };
 
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
+            var config = configurationBuilder.Build();
 
             var options = config.Get<List<NestedOptions>>("ObjectList");
 
@@ -140,8 +140,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"StringDictionary:ghi", "val_3"}
             };
 
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
+            var config = configurationBuilder.Build();
 
             var options = config.Get<Dictionary<string, string>>("StringDictionary");
 
@@ -163,8 +163,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"StringList:x", "valx"}
             };
 
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
+            var config = configurationBuilder.Build();
             var options = config.Get<OptionsWithLists>();
 
             var list = options.StringList;
@@ -188,8 +188,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"StringList:x", "valx"}
             };
 
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
+            var config = configurationBuilder.Build();
             var options = new OptionsWithLists();
             config.Bind(options);
 
@@ -214,8 +214,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"IntList:x", "45"}
             };
 
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
+            var config = configurationBuilder.Build();
 
             var options = config.Get<OptionsWithLists>();
 
@@ -240,8 +240,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"IntList:x", "45"}
             };
 
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
+            var config = configurationBuilder.Build();
             
             var options = new OptionsWithLists();
             config.Bind(options);
@@ -267,8 +267,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"AlreadyInitializedList:x", "valx"}
             };
 
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
+            var config = configurationBuilder.Build();
 
             var options = config.Get<OptionsWithLists>();
 
@@ -294,8 +294,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"CustomList:x", "valx"}
             };
 
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
+            var config = configurationBuilder.Build();
 
             var options = config.Get<OptionsWithLists>();
 
@@ -319,8 +319,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"ObjectList:2:Integer", "32"},
             };
 
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
+            var config = configurationBuilder.Build();
 
             var options = config.Get<OptionsWithLists>();
 
@@ -343,8 +343,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"NestedLists:1:2", "val12"},
             };
 
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
+            var config = configurationBuilder.Build();
 
             var options = config.Get<OptionsWithLists>();
 
@@ -369,8 +369,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"StringDictionary:ghi", "val_3"}
             };
 
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
+            var config = configurationBuilder.Build();
 
             var options = config.Get<OptionsWithDictionary>();
 
@@ -391,8 +391,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"IntDictionary:ghi", "44"}
             };
 
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
+            var config = configurationBuilder.Build();
 
             var options = config.Get<OptionsWithDictionary>();
 
@@ -413,8 +413,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"ObjectDictionary:ghi:Integer", "3"}
             };
 
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
+            var config = configurationBuilder.Build();
 
             var options = config.Get<OptionsWithDictionary>();
 
@@ -437,8 +437,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"ListDictionary:def:2", "def_2"}
             };
 
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
+            var config = configurationBuilder.Build();
 
             var options = config.Get<OptionsWithDictionary>();
 
@@ -465,8 +465,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"ObjectList:1:ListInNestedOption:2", "12"},
             };
 
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
+            var config = configurationBuilder.Build();
 
             var options = config.Get<OptionsWithLists>();
 
@@ -491,8 +491,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"NonStringKeyDictionary:ghi", "val_3"}
             };
 
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
+            var config = configurationBuilder.Build();
 
             var options = config.Get<OptionsWithDictionary>();
 
@@ -510,8 +510,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"StringArray:x", "valx"}
             };
 
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
+            var config = configurationBuilder.Build();
 
             var options = config.Get<OptionsWithArrays>();
 
@@ -537,8 +537,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"StringArray:x", "valx"}
             };
 
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
+            var config = configurationBuilder.Build();
             
             var instance = new OptionsWithArrays();
             config.Bind(instance);
@@ -564,8 +564,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"AlreadyInitializedArray:x", "valx"}
             };
 
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
+            var config = configurationBuilder.Build();
 
             var options = config.Get<OptionsWithArrays>();
             var array = options.AlreadyInitializedArray;
@@ -592,8 +592,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"AlreadyInitializedArray:x", "valx"}
             };
 
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
+            var config = configurationBuilder.Build();
 
             var options = new OptionsWithArrays();
             config.Bind(options);
@@ -623,8 +623,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"ObjectArray:1:ArrayInNestedOption:2", "12"},
             };
 
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
+            var config = configurationBuilder.Build();
             var options = new OptionsWithArrays();
             config.Bind(options);
 
@@ -648,8 +648,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"DimensionalArray:0:1", "b"}
             };
 
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
+            var config = configurationBuilder.Build();
             var options = new OptionsWithArrays();
 
             var exception = Assert.Throws<InvalidOperationException>(
@@ -671,8 +671,8 @@ namespace Microsoft.Framework.Configuration.Binder.Test
                 {"JaggedArray:1:2", "12"},
             };
 
-            var builder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder(new MemoryConfigurationProvider(input));
+            var config = configurationBuilder.Build();
             var options = new OptionsWithArrays();
             config.Bind(options);
 

--- a/test/Microsoft.Framework.Configuration.FileExtensions.Test/FileConfigurationBuilderExtensionsTest.cs
+++ b/test/Microsoft.Framework.Configuration.FileExtensions.Test/FileConfigurationBuilderExtensionsTest.cs
@@ -13,10 +13,10 @@ namespace Microsoft.Framework.Configuration.Json
         public void SetBasePath_ThrowsIfBasePathIsNull()
         {
             // Arrange
-            var builder = new ConfigurationBuilder();
+            var configurationBuilder = new ConfigurationBuilder();
 
             // Act and Assert
-            var ex = Assert.Throws<ArgumentNullException>(() => builder.SetBasePath(null));
+            var ex = Assert.Throws<ArgumentNullException>(() => configurationBuilder.SetBasePath(null));
             Assert.Equal("basePath", ex.ParamName);
         }
 
@@ -24,10 +24,10 @@ namespace Microsoft.Framework.Configuration.Json
         public void SetBasePath_CheckPropertiesValueOnBuilder()
         {
             var expectedBasePath = @"C:\ExamplePath";
-            var builder = new ConfigurationBuilder();
+            var configurationBuilder = new ConfigurationBuilder();
 
-            builder.SetBasePath(expectedBasePath);
-            Assert.Equal(expectedBasePath, builder.Properties["BasePath"]);
+            configurationBuilder.SetBasePath(expectedBasePath);
+            Assert.Equal(expectedBasePath, configurationBuilder.Properties["BasePath"]);
         }
 
         [Fact]
@@ -35,11 +35,11 @@ namespace Microsoft.Framework.Configuration.Json
         {
             // Arrange
             var testDir = Path.GetDirectoryName(Path.GetTempFileName());
-            var builder = new ConfigurationBuilder();
-            builder.SetBasePath(testDir);
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.SetBasePath(testDir);
 
             // Act
-            var actualPath = builder.GetBasePath();
+            var actualPath = configurationBuilder.GetBasePath();
 
             // Assert
             Assert.Equal(testDir, actualPath);
@@ -49,10 +49,10 @@ namespace Microsoft.Framework.Configuration.Json
         public void GetBasePath_ReturnEmptyIfNotSet()
         {
             // Arrange
-            var builder = new ConfigurationBuilder();
+            var configurationBuilder = new ConfigurationBuilder();
 
             // Act
-            var actualPath = builder.GetBasePath();
+            var actualPath = configurationBuilder.GetBasePath();
 
             // Assert
             Assert.Equal(string.Empty, actualPath);

--- a/test/Microsoft.Framework.Configuration.FunctionalTests/ArrayTests.cs
+++ b/test/Microsoft.Framework.Configuration.FunctionalTests/ArrayTests.cs
@@ -50,13 +50,13 @@ i=ini_i.i.i.i
         [Fact]
         public void DifferentConfigSources_Merged_KeysAreSorted()
         {
-            var builder = new ConfigurationBuilder();
-            builder.AddJsonFile(_json1ConfigFilePath);
-            builder.AddIniFile(_iniConfigFilePath);
-            builder.AddJsonFile(_json2ConfigFilePath);
-            builder.AddXmlFile(_xmlConfigFilePath);
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddJsonFile(_json1ConfigFilePath);
+            configurationBuilder.AddIniFile(_iniConfigFilePath);
+            configurationBuilder.AddJsonFile(_json2ConfigFilePath);
+            configurationBuilder.AddXmlFile(_xmlConfigFilePath);
 
-            var config = builder.Build();
+            var config = configurationBuilder.Build();
 
             var configurationSection = config.GetSection("address");
             var indexConfigurationSections = configurationSection.GetChildren().ToArray();
@@ -84,14 +84,14 @@ i=ini_i.i.i.i
         [Fact]
         public void DifferentConfigSources_Merged_WithOverwrites()
         {
-            var builder = new ConfigurationBuilder();
+            var configurationBuilder = new ConfigurationBuilder();
 
-            builder.AddJsonFile(_json1ConfigFilePath);
-            builder.AddIniFile(_iniConfigFilePath);
-            builder.AddJsonFile(_json2ConfigFilePath);
-            builder.AddXmlFile(_xmlConfigFilePath);
+            configurationBuilder.AddJsonFile(_json1ConfigFilePath);
+            configurationBuilder.AddIniFile(_iniConfigFilePath);
+            configurationBuilder.AddJsonFile(_json2ConfigFilePath);
+            configurationBuilder.AddXmlFile(_xmlConfigFilePath);
 
-            var config = builder.Build();
+            var config = configurationBuilder.Build();
 
             Assert.Equal("json_0.0.0.0", config["address:0"]);
             Assert.Equal("xml_1.1.1.1", config["address:1"]);

--- a/test/Microsoft.Framework.Configuration.FunctionalTests/ConfigurationTests.cs
+++ b/test/Microsoft.Framework.Configuration.FunctionalTests/ConfigurationTests.cs
@@ -78,15 +78,15 @@ CommonKey3:CommonKey4=IniValue6";
         public void LoadAndCombineKeyValuePairsFromDifferentConfigurationProviders()
         {
             // Arrange
-            var builder = new ConfigurationBuilder();
+            var configurationBuilder = new ConfigurationBuilder();
 
             // Act
-            builder.AddIniFile(_iniConfigFilePath);
-            builder.AddJsonFile(_jsonConfigFilePath);
-            builder.AddXmlFile(_xmlConfigFilePath);
-            builder.AddInMemoryCollection(_memConfigContent);
+            configurationBuilder.AddIniFile(_iniConfigFilePath);
+            configurationBuilder.AddJsonFile(_jsonConfigFilePath);
+            configurationBuilder.AddXmlFile(_xmlConfigFilePath);
+            configurationBuilder.AddInMemoryCollection(_memConfigContent);
 
-            var config = builder.Build();
+            var config = configurationBuilder.Build();
 
             // Assert
             Assert.Equal("IniValue1", config["IniKey1"]);
@@ -120,23 +120,23 @@ CommonKey3:CommonKey4=IniValue6";
         public void CanOverrideValuesWithNewConfigurationProvider()
         {
             // Arrange
-            var builder = new ConfigurationBuilder();
+            var configurationBuilder = new ConfigurationBuilder();
 
             // Act & Assert
-            builder.AddIniFile(_iniConfigFilePath);
-            var config = builder.Build();
+            configurationBuilder.AddIniFile(_iniConfigFilePath);
+            var config = configurationBuilder.Build();
             Assert.Equal("IniValue6", config["CommonKey1:CommonKey2:CommonKey3:CommonKey4"]);
 
-            builder.AddJsonFile(_jsonConfigFilePath);
-            config = builder.Build();
+            configurationBuilder.AddJsonFile(_jsonConfigFilePath);
+            config = configurationBuilder.Build();
             Assert.Equal("JsonValue6", config["CommonKey1:CommonKey2:CommonKey3:CommonKey4"]);
 
-            builder.AddXmlFile(_xmlConfigFilePath);
-            config = builder.Build();
+            configurationBuilder.AddXmlFile(_xmlConfigFilePath);
+            config = configurationBuilder.Build();
             Assert.Equal("XmlValue6", config["CommonKey1:CommonKey2:CommonKey3:CommonKey4"]);
 
-            builder.AddInMemoryCollection(_memConfigContent);
-            config = builder.Build();
+            configurationBuilder.AddInMemoryCollection(_memConfigContent);
+            config = configurationBuilder.Build();
             Assert.Equal("MemValue6", config["CommonKey1:CommonKey2:CommonKey3:CommonKey4"]);
         }
 
@@ -144,19 +144,19 @@ CommonKey3:CommonKey4=IniValue6";
         public void CanSetValuesAndReloadValues()
         {
             // Arrange
-            var builder = new ConfigurationBuilder();
-            builder.AddIniFile(_iniConfigFilePath);
-            builder.AddJsonFile(_jsonConfigFilePath);
-            builder.AddXmlFile(_xmlConfigFilePath);
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddIniFile(_iniConfigFilePath);
+            configurationBuilder.AddJsonFile(_jsonConfigFilePath);
+            configurationBuilder.AddXmlFile(_xmlConfigFilePath);
 
-            var config = builder.Build();
+            var config = configurationBuilder.Build();
 
             // Act & Assert
             // Set value
             config["CommonKey1:CommonKey2:CommonKey3:CommonKey4"] = "NewValue";
 
             // All config sources must be updated
-            foreach (var provider in builder.Providers)
+            foreach (var provider in configurationBuilder.Providers)
             {
                 Assert.Equal("NewValue",
                     (provider as ConfigurationProvider).Get("CommonKey1:CommonKey2:CommonKey3:CommonKey4"));
@@ -171,7 +171,7 @@ CommonKey3:CommonKey4=IniValue6";
             config["CommonKey1:CommonKey2:CommonKey3:CommonKey4"] = "NewValue";
 
             // All config sources must be updated
-            foreach (var provider in builder.Providers)
+            foreach (var provider in configurationBuilder.Providers)
             {
                 Assert.Equal("NewValue",
                     (provider as ConfigurationProvider).Get("CommonKey1:CommonKey2:CommonKey3:CommonKey4"));
@@ -209,17 +209,17 @@ CommonKey3:CommonKey4=IniValue6";
         public void SetBasePathCalledMultipleTimesForEachSource()
         {
             // Arrange
-            var builder = new ConfigurationBuilder();
+            var configurationBuilder = new ConfigurationBuilder();
             _jsonConfigFilePath = Path.Combine(Directory.GetCurrentDirectory(), "test.json");
             File.WriteAllText(_jsonConfigFilePath, _jsonConfigFileContent);
 
             // Act
-            builder.SetBasePath(Path.GetDirectoryName(_xmlConfigFilePath))
+            configurationBuilder.SetBasePath(Path.GetDirectoryName(_xmlConfigFilePath))
                 .AddXmlFile(Path.GetFileName(_xmlConfigFilePath))
                 .SetBasePath(Directory.GetCurrentDirectory())
                 .AddJsonFile("test.json");
 
-            var config = builder.Build();
+            var config = configurationBuilder.Build();
 
             // Assert
             Assert.Equal("JsonValue1", config["JsonKey1"]);

--- a/test/Microsoft.Framework.Configuration.Ini.Test/IniConfigurationExtensionsTest.cs
+++ b/test/Microsoft.Framework.Configuration.Ini.Test/IniConfigurationExtensionsTest.cs
@@ -15,11 +15,11 @@ namespace Microsoft.Framework.Configuration.Ini.Test
         public void AddIniFile_ThrowsIfFilePathIsNullOrEmpty(string path)
         {
             // Arrange
-            var builder = new ConfigurationBuilder();
+            var configurationBuilder = new ConfigurationBuilder();
 
             // Act and Assert
             var ex = Assert.Throws<ArgumentException>(
-                () => IniConfigurationExtensions.AddIniFile(builder, path));
+                () => IniConfigurationExtensions.AddIniFile(configurationBuilder, path));
             Assert.Equal("path", ex.ParamName);
             Assert.StartsWith("File path must be a non-empty string.", ex.Message);
         }
@@ -29,11 +29,11 @@ namespace Microsoft.Framework.Configuration.Ini.Test
         {
             // Arrange
             var path = Path.Combine(Directory.GetCurrentDirectory(), "file-does-not-exist.ini");
-            var builder = new ConfigurationBuilder();
+            var configurationBuilder = new ConfigurationBuilder();
 
             // Act and Assert
             var ex = Assert.Throws<FileNotFoundException>(
-                () => IniConfigurationExtensions.AddIniFile(builder, path));
+                () => IniConfigurationExtensions.AddIniFile(configurationBuilder, path));
             Assert.Equal($"The configuration file '{path}' was not found and is not optional.", ex.Message);
         }
     }

--- a/test/Microsoft.Framework.Configuration.Json.Test/ArrayTest.cs
+++ b/test/Microsoft.Framework.Configuration.Json.Test/ArrayTest.cs
@@ -101,10 +101,10 @@ namespace Microsoft.Framework.Configuration.Json.Test
             var jsonConfigSource2 = new JsonConfigurationProvider(TestStreamHelpers.ArbitraryFilePath);
             jsonConfigSource2.Load(TestStreamHelpers.StringToStream(json2));
 
-            var builder = new ConfigurationBuilder();
-            builder.Add(jsonConfigSource1, load: false);
-            builder.Add(jsonConfigSource2, load: false);
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.Add(jsonConfigSource1, load: false);
+            configurationBuilder.Add(jsonConfigSource2, load: false);
+            var config = configurationBuilder.Build();
 
             Assert.Equal(3, config.GetSection("ip").GetChildren().Count());
             Assert.Equal("15.16.17.18", config["ip:0"]);
@@ -135,10 +135,10 @@ namespace Microsoft.Framework.Configuration.Json.Test
             var jsonConfigSource2 = new JsonConfigurationProvider(TestStreamHelpers.ArbitraryFilePath);
             jsonConfigSource2.Load(TestStreamHelpers.StringToStream(json2));
 
-            var builder = new ConfigurationBuilder();
-            builder.Add(jsonConfigSource1, load: false);
-            builder.Add(jsonConfigSource2, load: false);
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.Add(jsonConfigSource1, load: false);
+            configurationBuilder.Add(jsonConfigSource2, load: false);
+            var config = configurationBuilder.Build();
 
             Assert.Equal(3, config.GetSection("ip").GetChildren().Count());
             Assert.Equal("1.2.3.4", config["ip:0"]);
@@ -169,10 +169,10 @@ namespace Microsoft.Framework.Configuration.Json.Test
             var jsonConfigSource2 = new JsonConfigurationProvider(TestStreamHelpers.ArbitraryFilePath);
             jsonConfigSource2.Load(TestStreamHelpers.StringToStream(json2));
 
-            var builder = new ConfigurationBuilder();
-            builder.Add(jsonConfigSource1, load: false);
-            builder.Add(jsonConfigSource2, load: false);
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.Add(jsonConfigSource1, load: false);
+            configurationBuilder.Add(jsonConfigSource2, load: false);
+            var config = configurationBuilder.Build();
 
             Assert.Equal(4, config.GetSection("ip").GetChildren().Count());
             Assert.Equal("1.2.3.4", config["ip:0"]);
@@ -195,9 +195,9 @@ namespace Microsoft.Framework.Configuration.Json.Test
             var jsonConfigSource = new JsonConfigurationProvider(TestStreamHelpers.ArbitraryFilePath);
             jsonConfigSource.Load(TestStreamHelpers.StringToStream(json));
 
-            var builder = new ConfigurationBuilder();
-            builder.Add(jsonConfigSource, load: false);
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.Add(jsonConfigSource, load: false);
+            var config = configurationBuilder.Build();
 
             var configurationSection = config.GetSection("setting");
             var indexConfigurationSections = configurationSection.GetChildren().ToArray();
@@ -225,9 +225,9 @@ namespace Microsoft.Framework.Configuration.Json.Test
             var jsonConfigSource = new JsonConfigurationProvider(TestStreamHelpers.ArbitraryFilePath);
             jsonConfigSource.Load(TestStreamHelpers.StringToStream(json));
 
-            var builder = new ConfigurationBuilder();
-            builder.Add(jsonConfigSource, load: false);
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.Add(jsonConfigSource, load: false);
+            var config = configurationBuilder.Build();
 
             var configurationSection = config.GetSection("setting");
             var indexConfigurationSections = configurationSection.GetChildren().ToArray();

--- a/test/Microsoft.Framework.Configuration.Json.Test/JsonConfigurationExtensionsTest.cs
+++ b/test/Microsoft.Framework.Configuration.Json.Test/JsonConfigurationExtensionsTest.cs
@@ -15,10 +15,10 @@ namespace Microsoft.Framework.Configuration.Json
         public void AddJsonFile_ThrowsIfFilePathIsNullOrEmpty(string path)
         {
             // Arrange
-            var builder = new ConfigurationBuilder();
+            var configurationBuilder = new ConfigurationBuilder();
 
             // Act and Assert
-            var ex = Assert.Throws<ArgumentException>(() => JsonConfigurationExtensions.AddJsonFile(builder, path));
+            var ex = Assert.Throws<ArgumentException>(() => JsonConfigurationExtensions.AddJsonFile(configurationBuilder, path));
             Assert.Equal("path", ex.ParamName);
             Assert.StartsWith("File path must be a non-empty string.", ex.Message);
         }
@@ -28,10 +28,10 @@ namespace Microsoft.Framework.Configuration.Json
         {
             // Arrange
             var path = Path.Combine(Directory.GetCurrentDirectory(), "file-does-not-exist.json");
-            var builder = new ConfigurationBuilder();
+            var configurationBuilder = new ConfigurationBuilder();
 
             // Act and Assert
-            var ex = Assert.Throws<FileNotFoundException>(() => JsonConfigurationExtensions.AddJsonFile(builder, path));
+            var ex = Assert.Throws<FileNotFoundException>(() => JsonConfigurationExtensions.AddJsonFile(configurationBuilder, path));
             Assert.Equal($"The configuration file '{path}' was not found and is not optional.", ex.Message);
         }
     }

--- a/test/Microsoft.Framework.Configuration.Test/ConfigurationTest.cs
+++ b/test/Microsoft.Framework.Configuration.Test/ConfigurationTest.cs
@@ -31,23 +31,23 @@ namespace Microsoft.Framework.Configuration.Test
             var memConfigSrc2 = new MemoryConfigurationProvider(dic2);
             var memConfigSrc3 = new MemoryConfigurationProvider(dic3);
 
-            var builder = new ConfigurationBuilder();
+            var configurationBuilder = new ConfigurationBuilder();
 
             // Act
-            builder.Add(memConfigSrc1, load: false);
-            builder.Add(memConfigSrc2, load: false);
-            builder.Add(memConfigSrc3, load: false);
+            configurationBuilder.Add(memConfigSrc1, load: false);
+            configurationBuilder.Add(memConfigSrc2, load: false);
+            configurationBuilder.Add(memConfigSrc3, load: false);
 
-            var config = builder.Build();
+            var config = configurationBuilder.Build();
 
             var memVal1 = config["mem1:keyinmem1"];
             var memVal2 = config["Mem2:KeyInMem2"];
             var memVal3 = config["MEM3:KEYINMEM3"];
 
             // Assert
-            Assert.Contains(memConfigSrc1, builder.Providers);
-            Assert.Contains(memConfigSrc2, builder.Providers);
-            Assert.Contains(memConfigSrc3, builder.Providers);
+            Assert.Contains(memConfigSrc1, configurationBuilder.Providers);
+            Assert.Contains(memConfigSrc2, configurationBuilder.Providers);
+            Assert.Contains(memConfigSrc3, configurationBuilder.Providers);
 
             Assert.Equal("ValueInMem1", memVal1);
             Assert.Equal("ValueInMem2", memVal2);
@@ -74,13 +74,13 @@ namespace Microsoft.Framework.Configuration.Test
             var memConfigSrc1 = new MemoryConfigurationProvider(dic1);
             var memConfigSrc2 = new MemoryConfigurationProvider(dic2);
 
-            var builder = new ConfigurationBuilder();
+            var configurationBuilder = new ConfigurationBuilder();
 
             // Act
-            builder.Add(memConfigSrc1, load: false);
-            builder.Add(memConfigSrc2, load: false);
+            configurationBuilder.Add(memConfigSrc1, load: false);
+            configurationBuilder.Add(memConfigSrc2, load: false);
 
-            var config = builder.Build();
+            var config = configurationBuilder.Build();
 
             // Assert
             Assert.Equal("ValueInMem2", config["Key1:Key2"]);
@@ -99,13 +99,13 @@ namespace Microsoft.Framework.Configuration.Test
             var memConfigSrc2 = new MemoryConfigurationProvider(dict);
             var memConfigSrc3 = new MemoryConfigurationProvider(dict);
 
-            var builder = new ConfigurationBuilder();
+            var configurationBuilder = new ConfigurationBuilder();
 
-            builder.Add(memConfigSrc1, load: false);
-            builder.Add(memConfigSrc2, load: false);
-            builder.Add(memConfigSrc3, load: false);
+            configurationBuilder.Add(memConfigSrc1, load: false);
+            configurationBuilder.Add(memConfigSrc2, load: false);
+            configurationBuilder.Add(memConfigSrc3, load: false);
 
-            var config = builder.Build();
+            var config = configurationBuilder.Build();
 
             // Act
             config["Key1"] = "NewValue1";
@@ -143,12 +143,12 @@ namespace Microsoft.Framework.Configuration.Test
             var memConfigSrc2 = new MemoryConfigurationProvider(dic2);
             var memConfigSrc3 = new MemoryConfigurationProvider(dic3);
 
-            var builder = new ConfigurationBuilder();
-            builder.Add(memConfigSrc1, load: false);
-            builder.Add(memConfigSrc2, load: false);
-            builder.Add(memConfigSrc3, load: false);
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.Add(memConfigSrc1, load: false);
+            configurationBuilder.Add(memConfigSrc2, load: false);
+            configurationBuilder.Add(memConfigSrc3, load: false);
 
-            var config = builder.Build();
+            var config = configurationBuilder.Build();
 
             // Act
             var configFocus = config.GetSection("Data");
@@ -192,12 +192,12 @@ namespace Microsoft.Framework.Configuration.Test
             var memConfigSrc2 = new MemoryConfigurationProvider(dic2);
             var memConfigSrc3 = new MemoryConfigurationProvider(dic3);
 
-            var builder = new ConfigurationBuilder();
-            builder.Add(memConfigSrc1, load: false);
-            builder.Add(memConfigSrc2, load: false);
-            builder.Add(memConfigSrc3, load: false);
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.Add(memConfigSrc1, load: false);
+            configurationBuilder.Add(memConfigSrc2, load: false);
+            configurationBuilder.Add(memConfigSrc3, load: false);
 
-            var config = builder.Build();
+            var config = configurationBuilder.Build();
 
             // Act
             var configSections = config.GetSection("Data").GetChildren().ToList();
@@ -230,25 +230,25 @@ namespace Microsoft.Framework.Configuration.Test
                 memConfigSrc3
             };
 
-            var builder = new ConfigurationBuilder();
+            var configurationBuilder = new ConfigurationBuilder();
 
             // Act
-            builder.Add(memConfigSrc1, load: false);
-            builder.Add(memConfigSrc2, load: false);
-            builder.Add(memConfigSrc3, load: false);
+            configurationBuilder.Add(memConfigSrc1, load: false);
+            configurationBuilder.Add(memConfigSrc2, load: false);
+            configurationBuilder.Add(memConfigSrc3, load: false);
 
-            var config = builder.Build();
+            var config = configurationBuilder.Build();
 
             // Assert
-            Assert.Equal(new[] { memConfigSrc1, memConfigSrc2, memConfigSrc3 }, builder.Providers);
+            Assert.Equal(new[] { memConfigSrc1, memConfigSrc2, memConfigSrc3 }, configurationBuilder.Providers);
         }
 
         [Fact]
         public void SetValueThrowsExceptionNoSourceRegistered()
         {
             // Arrange
-            var builder = new ConfigurationBuilder();
-            var config = builder.Build();
+            var configurationBuilder = new ConfigurationBuilder();
+            var config = configurationBuilder.Build();
 
             var expectedMsg = Resources.Error_NoSources;
 

--- a/test/Microsoft.Framework.Configuration.Xml.Test/XmlConfigurationExtensionsTest.cs
+++ b/test/Microsoft.Framework.Configuration.Xml.Test/XmlConfigurationExtensionsTest.cs
@@ -15,10 +15,10 @@ namespace Microsoft.Framework.Configuration.Xml.Test
         public void AddXmlFile_ThrowsIfFilePathIsNullOrEmpty(string path)
         {
             // Arrange
-            var builder = new ConfigurationBuilder();
+            var configurationBuilder = new ConfigurationBuilder();
 
             // Act and Assert
-            var ex = Assert.Throws<ArgumentException>(() => XmlConfigurationExtensions.AddXmlFile(builder, path));
+            var ex = Assert.Throws<ArgumentException>(() => XmlConfigurationExtensions.AddXmlFile(configurationBuilder, path));
             Assert.Equal("path", ex.ParamName);
             Assert.StartsWith("File path must be a non-empty string.", ex.Message);
         }
@@ -28,10 +28,10 @@ namespace Microsoft.Framework.Configuration.Xml.Test
         {
             // Arrange
             var path = Path.Combine(Directory.GetCurrentDirectory(), "file-does-not-exist.xml");
-            var builder = new ConfigurationBuilder();
+            var configurationBuilder = new ConfigurationBuilder();
 
             // Act and Assert
-            var ex = Assert.Throws<FileNotFoundException>(() => XmlConfigurationExtensions.AddXmlFile(builder, path));
+            var ex = Assert.Throws<FileNotFoundException>(() => XmlConfigurationExtensions.AddXmlFile(configurationBuilder, path));
             Assert.Equal($"The configuration file '{path}' was not found and is not optional.", ex.Message);
         }
     }


### PR DESCRIPTION
cc @divega 