### PR TITLE
Enable binding of IConfiguration/IConfigurationSection

### DIFF
--- a/src/Microsoft.Extensions.Configuration.Binder/ConfigurationBinder.cs
+++ b/src/Microsoft.Extensions.Configuration.Binder/ConfigurationBinder.cs
@@ -82,6 +82,7 @@ namespace Microsoft.Extensions.Configuration
             }
 
             propertyValue = BindInstance(property.PropertyType, propertyValue, config.GetSection(property.Name));
+
             if (propertyValue != null && hasPublicSetter)
             {
                 property.SetValue(instance, propertyValue);
@@ -90,6 +91,12 @@ namespace Microsoft.Extensions.Configuration
 
         private static object BindInstance(Type type, object instance, IConfiguration config)
         {
+            // if binding IConfigurationSection, break early
+            if (type == typeof(IConfigurationSection))
+            {
+                return config;
+            }
+
             var section = config as IConfigurationSection;
             var configValue = section?.Value;
             if (configValue != null)


### PR DESCRIPTION
Enable binding of `IConfigurationSection` when calling `ConfigurationBinder.Bind()`
- Treats `IConfigurationSection` as a unique case when binding a property
- Normal property name -> config section mapping applies

Addresses #274 and https://github.com/aspnet/Options/issues/60