### PR TITLE
Modify ConfigurationBuilder.GetBasePath() does not return an absolute path on Mono

### DIFF
--- a/src/Microsoft.Extensions.Configuration.FileExtensions/FileConfigurationExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.FileExtensions/FileConfigurationExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 
 namespace Microsoft.Extensions.Configuration
 {
@@ -26,7 +27,7 @@ namespace Microsoft.Extensions.Configuration
             }
 
             configurationBuilder.Properties["BasePath"] = basePath;
-            
+
             return configurationBuilder;
         }
 
@@ -49,8 +50,13 @@ namespace Microsoft.Extensions.Configuration
             }
 
 #if NET451
-            return AppDomain.CurrentDomain.GetData("APP_CONTEXT_BASE_DIRECTORY") as string ??
-                AppDomain.CurrentDomain.BaseDirectory ?? string.Empty;
+            var stringBasePath =
+                AppDomain.CurrentDomain.GetData("APP_CONTEXT_BASE_DIRECTORY") as string ??
+                AppDomain.CurrentDomain.BaseDirectory ??
+                string.Empty;
+
+            // On Mono, the value of APP_CONTEXT_BASE_DIRECTORY is ".". We'll expand it to get the full base path.
+            return Path.GetFullPath(stringBasePath);
 #else
             return AppContext.BaseDirectory ?? string.Empty;
 #endif

--- a/src/Microsoft.Extensions.Configuration.FileProviderExtensions/ConfigurationRootExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.FileProviderExtensions/ConfigurationRootExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using Microsoft.AspNet.FileProviders;
 
 namespace Microsoft.Extensions.Configuration
@@ -20,8 +21,13 @@ namespace Microsoft.Extensions.Configuration
                 throw new ArgumentNullException(nameof(filename));
             }
 #if NET451
-            var basePath = AppDomain.CurrentDomain.GetData("APP_CONTEXT_BASE_DIRECTORY") as string ??
-                AppDomain.CurrentDomain.BaseDirectory ?? string.Empty;
+            var basePath =
+                AppDomain.CurrentDomain.GetData("APP_CONTEXT_BASE_DIRECTORY") as string ??
+                AppDomain.CurrentDomain.BaseDirectory ??
+                string.Empty;
+
+            // On Mono, the value of APP_CONTEXT_BASE_DIRECTORY is ".". We'll expand it to get the full base path.
+            basePath = Path.GetFullPath(basePath);
 #else
             var basePath = AppContext.BaseDirectory ?? string.Empty;
 #endif

--- a/test/Microsoft.Extensions.Configuration.FileExtensions.Test/FileConfigurationBuilderExtensionsTest.cs
+++ b/test/Microsoft.Extensions.Configuration.FileExtensions.Test/FileConfigurationBuilderExtensionsTest.cs
@@ -54,13 +54,12 @@ namespace Microsoft.Extensions.Configuration.Json
             // Act
             var actualPath = configurationBuilder.GetBasePath();
 
-            string expectedPath = string.Empty;
+            string expectedPath;
 
 #if DNXCORE50
-             expectedPath = AppContext.BaseDirectory;
+            expectedPath = AppContext.BaseDirectory;
 #else
-            expectedPath = AppDomain.CurrentDomain.GetData("APP_CONTEXT_BASE_DIRECTORY") as string ??
-                AppDomain.CurrentDomain.BaseDirectory ?? string.Empty;
+            expectedPath = Path.GetFullPath((string)AppDomain.CurrentDomain.GetData("APP_CONTEXT_BASE_DIRECTORY"));
 #endif
 
             // Assert

--- a/test/Microsoft.Extensions.Configuration.FunctionalTests/ConfigurationTests.cs
+++ b/test/Microsoft.Extensions.Configuration.FunctionalTests/ConfigurationTests.cs
@@ -241,13 +241,12 @@ CommonKey3:CommonKey4=IniValue6";
         {
             // Arrange
             var builder = new ConfigurationBuilder();
-            string filePath = string.Empty;
+            string filePath;
 
 #if DNXCORE50
-             filePath = AppContext.BaseDirectory ?? string.Empty;
+            filePath = AppContext.BaseDirectory;
 #else
-            filePath = AppDomain.CurrentDomain.GetData("APP_CONTEXT_BASE_DIRECTORY") as string ??
-                AppDomain.CurrentDomain.BaseDirectory ?? string.Empty;
+            filePath = Path.GetFullPath((string)AppDomain.CurrentDomain.GetData("APP_CONTEXT_BASE_DIRECTORY"));
 #endif
 
             var jsonConfigFilePath = Path.Combine(filePath, "test.json");


### PR DESCRIPTION
Fixes #336