### PR TITLE
fix issue #335 with canseek

### DIFF
--- a/test/Microsoft.Extensions.Configuration.Json.Test/JsonConfigurationTest.cs
+++ b/test/Microsoft.Extensions.Configuration.Json.Test/JsonConfigurationTest.cs
@@ -134,5 +134,15 @@ namespace Microsoft.Extensions.Configuration
             configSource.Load();
             Assert.Throws<InvalidOperationException>(() => configSource.Get("key"));
         }
+
+        [Fact]
+        public void ThrowFormatExceptionWhenFileIsEmpty()
+        {
+            var json = @"";
+            var jsonConfigSource = new JsonConfigurationProvider(TestStreamHelpers.ArbitraryFilePath);
+
+            var exception = Assert.Throws<FormatException>(
+                () => jsonConfigSource.Load(TestStreamHelpers.StringToStream(json)));
+        }
     }
 }


### PR DESCRIPTION
Problem was that error handler was throwing ArgumentOutOfRangeException while trying to construct error message.

Summary of the changes:

- add test
- fix issue by avoiding access to unavailable element
- some refactoring to make things readable

Addresses #335 issue. 

This PR is alternative to #337.