### PR TITLE
Reverting behaviour change to setting configuration base path

### DIFF
--- a/src/Microsoft.Extensions.Configuration.FileExtensions/FileConfigurationExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.FileExtensions/FileConfigurationExtensions.cs
@@ -50,7 +50,9 @@ namespace Microsoft.Extensions.Configuration
             }
 
 #if NET451
-            var stringBasePath = AppDomain.CurrentDomain.BaseDirectory ?? string.Empty;
+            var stringBasePath = AppDomain.CurrentDomain.GetData("APP_CONTEXT_BASE_DIRECTORY") as string ??
+                AppDomain.CurrentDomain.BaseDirectory ?? 
+                string.Empty;
 
             return Path.GetFullPath(stringBasePath);
 #else

--- a/src/Microsoft.Extensions.Configuration.FileProviderExtensions/ConfigurationRootExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.FileProviderExtensions/ConfigurationRootExtensions.cs
@@ -21,7 +21,9 @@ namespace Microsoft.Extensions.Configuration
                 throw new ArgumentNullException(nameof(filename));
             }
 #if NET451
-            var basePath = AppDomain.CurrentDomain.BaseDirectory ?? string.Empty;
+            var basePath = AppDomain.CurrentDomain.GetData("APP_CONTEXT_BASE_DIRECTORY") as string ??
+                AppDomain.CurrentDomain.BaseDirectory ?? 
+                string.Empty;
 #else
             var basePath = AppContext.BaseDirectory ?? string.Empty;
 #endif

--- a/test/Microsoft.Extensions.Configuration.FileExtensions.Test/FileConfigurationBuilderExtensionsTest.cs
+++ b/test/Microsoft.Extensions.Configuration.FileExtensions.Test/FileConfigurationBuilderExtensionsTest.cs
@@ -59,7 +59,8 @@ namespace Microsoft.Extensions.Configuration.Json
 #if DNXCORE50
             expectedPath = AppContext.BaseDirectory;
 #else
-            expectedPath = Path.GetFullPath(AppDomain.CurrentDomain.BaseDirectory);
+            expectedPath = Path.GetFullPath(AppDomain.CurrentDomain.GetData("APP_CONTEXT_BASE_DIRECTORY") as string ?? 
+                AppDomain.CurrentDomain.BaseDirectory);
 #endif
 
             // Assert

--- a/test/Microsoft.Extensions.Configuration.FunctionalTests/ConfigurationTests.cs
+++ b/test/Microsoft.Extensions.Configuration.FunctionalTests/ConfigurationTests.cs
@@ -246,7 +246,8 @@ CommonKey3:CommonKey4=IniValue6";
 #if DNXCORE50
             filePath = AppContext.BaseDirectory;
 #else
-            filePath = Path.GetFullPath((string)AppDomain.CurrentDomain.BaseDirectory);
+            filePath = Path.GetFullPath(AppDomain.CurrentDomain.GetData("APP_CONTEXT_BASE_DIRECTORY") as string ??
+                AppDomain.CurrentDomain.BaseDirectory);
 #endif
 
             var jsonConfigFilePath = Path.Combine(filePath, "test.json");


### PR DESCRIPTION
Currently all of our samples are broken when running with dnx since configuration cannot find the `hosting.json` that is in the sample's directory. Instead, it is looking for it in the runtime directory as indicated by the appdomain. We'll revert the behaviour change for now.

cc @victorhurdugaci 