### PR TITLE
Removing mono specific test message

### DIFF
--- a/test/Microsoft.Extensions.Configuration.Xml.Test/XmlConfigurationTest.cs
+++ b/test/Microsoft.Extensions.Configuration.Xml.Test/XmlConfigurationTest.cs
@@ -300,8 +300,7 @@ namespace Microsoft.Extensions.Configuration.Xml.Test
                     </Data>
                 </settings>";
             var xmlConfigSrc = new XmlConfigurationProvider(ArbitraryFilePath);
-            var isMono = Type.GetType("Mono.Runtime") != null;
-            var expectedMsg = isMono ? "Document Type Declaration (DTD) is prohibited in this XML.  Line 1, position 10." : "For security reasons DTD is prohibited in this XML document. "
+            var expectedMsg = "For security reasons DTD is prohibited in this XML document. "
                 + "To enable DTD processing set the DtdProcessing property on XmlReaderSettings "
                 + "to Parse and pass the settings into XmlReader.Create method.";
 


### PR DESCRIPTION
We are no longer running tests in mono runtime. The reason this test fails currently on linux is because we use mono framework library dependencies causing the test to use the mono message.