### PR TITLE
Allow binding already initialized IDictionary

### DIFF
--- a/src/Microsoft.Extensions.Configuration.Binder/ConfigurationBinder.cs
+++ b/src/Microsoft.Extensions.Configuration.Binder/ConfigurationBinder.cs
@@ -285,7 +285,14 @@ namespace Microsoft.Extensions.Configuration
 
         private static Type FindOpenGenericInterface(Type expected, Type actual)
         {
-            var interfaces = actual.GetTypeInfo().ImplementedInterfaces;
+            var actualTypeInfo = actual.GetTypeInfo();
+            if(actualTypeInfo.IsGenericType && 
+                actual.GetGenericTypeDefinition() == expected)
+            {
+                return actual;
+            } 
+             
+            var interfaces = actualTypeInfo.ImplementedInterfaces;
             foreach (var interfaceType in interfaces)
             {
                 if (interfaceType.GetTypeInfo().IsGenericType &&

--- a/test/Microsoft.Extensions.Configuration.Binder.Test/ConfigurationCollectionBindingTests.cs
+++ b/test/Microsoft.Extensions.Configuration.Binder.Test/ConfigurationCollectionBindingTests.cs
@@ -287,6 +287,35 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
         }
 
         [Fact]
+        public void AlreadyInitializedListInterfaceBinding()
+        {
+            var input = new Dictionary<string, string>
+            {
+                {"AlreadyInitializedListInterface:0", "val0"},
+                {"AlreadyInitializedListInterface:1", "val1"},
+                {"AlreadyInitializedListInterface:2", "val2"},
+                {"AlreadyInitializedListInterface:x", "valx"}
+            };
+
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(input);
+            var config = configurationBuilder.Build();
+
+            var options = new OptionsWithLists();
+            config.Bind(options);
+
+            var list = options.AlreadyInitializedListInterface;
+
+            Assert.Equal(5, list.Count);
+
+            Assert.Equal("This was here too", list[0]);
+            Assert.Equal("val0", list[1]);
+            Assert.Equal("val1", list[2]);
+            Assert.Equal("val2", list[3]);
+            Assert.Equal("valx", list[4]);
+        }        
+
+        [Fact]
         public void CustomListBinding()
         {
             var input = new Dictionary<string, string>
@@ -765,6 +794,8 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             {
                 AlreadyInitializedList = new List<string>();
                 AlreadyInitializedList.Add("This was here before");
+                AlreadyInitializedListInterface = new List<string>();
+                AlreadyInitializedListInterface.Add("This was here too");
             }
 
             public CustomList CustomList { get; set; }
@@ -782,6 +813,8 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             public List<string> AlreadyInitializedList { get; set; }
 
             public List<NestedOptions> ObjectList { get; set; }
+            
+            public IList<string> AlreadyInitializedListInterface { get; set; }
         }
 
         private class OptionsWithDictionary

--- a/test/Microsoft.Extensions.Configuration.Binder.Test/ConfigurationCollectionBindingTests.cs
+++ b/test/Microsoft.Extensions.Configuration.Binder.Test/ConfigurationCollectionBindingTests.cs
@@ -420,6 +420,32 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             Assert.Equal("val_2", options.StringDictionary["def"]);
             Assert.Equal("val_3", options.StringDictionary["ghi"]);
         }
+        
+        [Fact]
+        public void AlreadyInitializedStringDictionaryBinding()
+        {
+            var input = new Dictionary<string, string>
+            {
+                {"AlreadyInitializedStringDictionaryInterface:abc", "val_1"},
+                {"AlreadyInitializedStringDictionaryInterface:def", "val_2"},
+                {"AlreadyInitializedStringDictionaryInterface:ghi", "val_3"}
+            };
+
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(input);
+            var config = configurationBuilder.Build();
+
+            var options = new OptionsWithDictionary();
+            config.Bind(options);
+
+            Assert.NotNull(options.AlreadyInitializedStringDictionaryInterface);
+            Assert.Equal(4, options.AlreadyInitializedStringDictionaryInterface.Count);
+
+            Assert.Equal("This was already here", options.AlreadyInitializedStringDictionaryInterface["123"]);
+            Assert.Equal("val_1", options.AlreadyInitializedStringDictionaryInterface["abc"]);
+            Assert.Equal("val_2", options.AlreadyInitializedStringDictionaryInterface["def"]);
+            Assert.Equal("val_3", options.AlreadyInitializedStringDictionaryInterface["ghi"]);
+        }
 
         [Fact]
         public void IntDictionaryBinding()
@@ -819,6 +845,12 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
 
         private class OptionsWithDictionary
         {
+            public OptionsWithDictionary()
+            {
+                AlreadyInitializedStringDictionaryInterface = new Dictionary<string, string>();
+                AlreadyInitializedStringDictionaryInterface["123"] = "This was already here";
+            }
+            
             public Dictionary<string, int> IntDictionary { get; set; }
 
             public Dictionary<string, string> StringDictionary { get; set; }
@@ -828,6 +860,12 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             public Dictionary<string, List<string>> ListDictionary { get; set; }
 
             public Dictionary<NestedOptions, string> NonStringKeyDictionary { get; set; }
+            
+            // This cannot be initialized because we cannot
+            // activate an interface
+            public IDictionary<string, string> StringDictionaryInterface { get; set; }
+            
+            public IDictionary<string, string> AlreadyInitializedStringDictionaryInterface { get; set; }
         }
     }
 }


### PR DESCRIPTION
Update `FindOpenGenericInterface` to return provided type if it is the interface
 - Add unit test to confirm existing behaviour that already initialised lists are bound correctly
 - Update `ConfigurationBinder` so can bind `IDictionary<,>` properties as well as properties that implement `IDictionary<,> `
 - `FindOpenGenericInterface` checks to see if the provided `Type actual` is `Type expected` before checking the implemented interfaces
 - Add unit test to confirm can now bind already initialised `IDictionary<,>`

Addresses #442