### PR TITLE
Added ability for GetConnectionString to handle typical xml App.confi…

### DIFF
--- a/src/Microsoft.Extensions.Configuration.Abstractions/ConfigurationExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.Abstractions/ConfigurationExtensions.cs
@@ -18,7 +18,18 @@ namespace Microsoft.Extensions.Configuration
         /// <returns></returns>
         public static string GetConnectionString(this IConfiguration configuration, string name)
         {
-            return configuration?.GetSection("ConnectionStrings")?[name];
+            var section = configuration?.GetSection("ConnectionStrings");
+            var result = section?[name];
+
+            if (result != null)
+                return result;
+
+            section = configuration?.GetSection($"connectionStrings:add:{name}:connectionString");
+            if (section != null)
+            {
+                result = section.Value;
+            }
+            return result;
         }
 
         /// <summary>

--- a/test/Microsoft.Extensions.Configuration.Test/ConfigurationTest.cs
+++ b/test/Microsoft.Extensions.Configuration.Test/ConfigurationTest.cs
@@ -265,6 +265,50 @@ namespace Microsoft.Extensions.Configuration.Test
         }
 
         [Fact]
+        public void CanGetAppConfigConnectionStrings()
+        {
+            // Arrange
+            var dic = new Dictionary<string, string>()
+            {
+                {"connectionStrings:add:DefaultConnection:connectionString", "MemVal"},
+            };
+
+            var memConfigSrc = new MemoryConfigurationSource { InitialData = dic };
+
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.Add(memConfigSrc);
+
+            var config = configurationBuilder.Build();
+
+            // Act
+            var memVal = config.GetConnectionString("DefaultConnection");
+
+            // Assert
+            Assert.Equal("MemVal", memVal);
+        }
+
+        [Fact]
+        public void GetConnectionStringReturnsNullIfDoesntExist()
+        {
+            // Arrange
+            var dic = new Dictionary<string, string>()
+            {};
+
+            var memConfigSrc = new MemoryConfigurationSource { InitialData = dic };
+
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.Add(memConfigSrc);
+
+            var config = configurationBuilder.Build();
+
+            // Act
+            var memVal = config.GetConnectionString("DefaultConnection");
+
+            // Assert
+            Assert.Null(memVal);
+        }
+
+        [Fact]
         public void CanGetConfigurationChildren()
         {
             // Arrange


### PR DESCRIPTION
When using `AddXmlFile`, `GetConnectionString` extension method now works when using connection strings in a web.config or app.config type schema.
When a connection string is specified in a xml file like App.config I would still expect `GetConnectionString` method to work. This might fall outside asp.net but as a standalone package that handles xml its probably not unreasonable.