### PR TITLE
Make ConfigurationExtensions partial

### DIFF
--- a/src/Microsoft.Extensions.Configuration.Abstractions/ConfigurationExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.Abstractions/ConfigurationExtensions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Extensions.Configuration
     /// <summary>
     /// Extension methods for <see cref="IConfiguration" />.
     /// </summary>
-    public static class ConfigurationExtensions
+    public static partial class ConfigurationExtensions
     {
         /// <summary>
         /// Shorthand for GetSection("ConnectionStrings")[name].


### PR DESCRIPTION
Make ConfigurationExtensions partial to avoid conflict with Microsoft.Extensions.Configuration.UserSecrets. Proposed fix for https://github.com/aspnet/Configuration/issues/490. See also my pull request for https://github.com/aspnet/UserSecrets which does the same thing to the latter:

https://github.com/aspnet/UserSecrets/pull/91