### PR TITLE
Fix reload behaviors + Add OnLoadError event for file based config providers

### DIFF
--- a/src/Microsoft.Extensions.Configuration.FileExtensions/FileConfigurationExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.FileExtensions/FileConfigurationExtensions.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Extensions.Configuration
     public static class FileConfigurationExtensions
     {
         private static string FileProviderKey = "FileProvider";
+        private static string FileLoadExceptionHandlerKey = "FileLoadExceptionHandler";
 
         /// <summary>
         /// Sets the default <see cref="IFileProvider"/> to be used for file-based providers.
@@ -54,8 +55,8 @@ namespace Microsoft.Extensions.Configuration
             }
 
 #if NET451
-            var stringBasePath = AppDomain.CurrentDomain.GetData("APP_CONTEXT_BASE_DIRECTORY") as string 
-                ?? AppDomain.CurrentDomain.BaseDirectory 
+            var stringBasePath = AppDomain.CurrentDomain.GetData("APP_CONTEXT_BASE_DIRECTORY") as string
+                ?? AppDomain.CurrentDomain.BaseDirectory
                 ?? string.Empty;
             return new PhysicalFileProvider(stringBasePath);
 #else
@@ -82,6 +83,43 @@ namespace Microsoft.Extensions.Configuration
             }
 
             return builder.SetFileProvider(new PhysicalFileProvider(basePath));
+        }
+
+        /// <summary>
+        /// Sets a default action to be invoked for file-based providers when an error occurs.
+        /// </summary>
+        /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="handler">The Action to be invoked on a file load exception.</param>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder SetFileLoadExceptionHandler(this IConfigurationBuilder builder, Action<FileLoadExceptionContext> handler)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            builder.Properties[FileLoadExceptionHandlerKey] = handler;
+            return builder;
+        }
+
+        /// <summary>
+        /// Gets the default <see cref="IFileProvider"/> to be used for file-based providers.
+        /// </summary>
+        /// <param name="builder">The <see cref="IConfigurationBuilder"/>.</param>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static Action<FileLoadExceptionContext> GetFileLoadExceptionHandler(this IConfigurationBuilder builder)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            object handler;
+            if (builder.Properties.TryGetValue(FileLoadExceptionHandlerKey, out handler))
+            {
+                return builder.Properties[FileLoadExceptionHandlerKey] as Action<FileLoadExceptionContext>;
+            }
+            return null;
         }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.FileExtensions/FileConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.FileExtensions/FileConfigurationProvider.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Threading;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Extensions.Configuration
@@ -30,7 +31,10 @@ namespace Microsoft.Extensions.Configuration
             {
                 ChangeToken.OnChange(
                     () => Source.FileProvider.Watch(Source.Path),
-                    () => Load(reload: true));
+                    () => {
+                        Thread.Sleep(Source.ReloadDelay);
+                        Load(reload: true);
+                    });
             }
         }
 
@@ -60,6 +64,11 @@ namespace Microsoft.Extensions.Configuration
             }
             else
             {
+                // Always create new Data on reload to drop old keys
+                if (reload)
+                {
+                    Data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                }
                 using (var stream = file.CreateReadStream())
                 {
                     try

--- a/src/Microsoft.Extensions.Configuration.FileExtensions/FileConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.FileExtensions/FileConfigurationProvider.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Extensions.Configuration
@@ -63,7 +62,15 @@ namespace Microsoft.Extensions.Configuration
             {
                 using (var stream = file.CreateReadStream())
                 {
-                    Load(stream);
+                    try
+                    {
+                        Load(stream);
+                    }
+                    catch (Exception e)
+                    {
+                        Source?.OnLoadError(e);
+                        throw e;
+                    }
                 }
             }
             // REVIEW: Should we raise this in the base as well / instead?

--- a/src/Microsoft.Extensions.Configuration.FileExtensions/FileConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.FileExtensions/FileConfigurationProvider.cs
@@ -68,8 +68,17 @@ namespace Microsoft.Extensions.Configuration
                     }
                     catch (Exception e)
                     {
-                        Source.OnLoadError?.Invoke(e);
-                        throw e;
+                        bool ignoreException = false;
+                        if (Source.OnLoadException != null)
+                        {
+                            var exceptionContext = new FileLoadExceptionContext { Exception = e };
+                            Source.OnLoadException.Invoke(exceptionContext);
+                            ignoreException = exceptionContext.Ignore;
+                        }
+                        if (!ignoreException)
+                        {
+                            throw e;
+                        }
                     }
                 }
             }

--- a/src/Microsoft.Extensions.Configuration.FileExtensions/FileConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.FileExtensions/FileConfigurationProvider.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Extensions.Configuration
                     }
                     catch (Exception e)
                     {
-                        Source?.OnLoadError(e);
+                        Source.OnLoadError?.Invoke(e);
                         throw e;
                     }
                 }

--- a/src/Microsoft.Extensions.Configuration.FileExtensions/FileConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.FileExtensions/FileConfigurationProvider.cs
@@ -71,7 +71,11 @@ namespace Microsoft.Extensions.Configuration
                         bool ignoreException = false;
                         if (Source.OnLoadException != null)
                         {
-                            var exceptionContext = new FileLoadExceptionContext { Exception = e };
+                            var exceptionContext = new FileLoadExceptionContext
+                            {
+                                Provider = this,
+                                Exception = e
+                            };
                             Source.OnLoadException.Invoke(exceptionContext);
                             ignoreException = exceptionContext.Ignore;
                         }

--- a/src/Microsoft.Extensions.Configuration.FileExtensions/FileConfigurationSource.cs
+++ b/src/Microsoft.Extensions.Configuration.FileExtensions/FileConfigurationSource.cs
@@ -45,6 +45,16 @@ namespace Microsoft.Extensions.Configuration
         public abstract IConfigurationProvider Build(IConfigurationBuilder builder);
 
         /// <summary>
+        /// Called to use any default settings on the builder like the FileProvider or FileLoadExceptionHandler.
+        /// </summary>
+        /// <param name="builder">The <see cref="IConfigurationBuilder"/>.</param>
+        public void EnsureDefaults(IConfigurationBuilder builder)
+        {
+            FileProvider = FileProvider ?? builder.GetFileProvider();
+            OnLoadException = OnLoadException ?? builder.GetFileLoadExceptionHandler();
+        }
+
+        /// <summary>
         /// If no file provider has been set, for absolute Path, this will creates a physical file provider 
         /// for the nearest existing directory.
         /// </summary>

--- a/src/Microsoft.Extensions.Configuration.FileExtensions/FileConfigurationSource.cs
+++ b/src/Microsoft.Extensions.Configuration.FileExtensions/FileConfigurationSource.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using Microsoft.Extensions.FileProviders;
 
@@ -30,6 +31,11 @@ namespace Microsoft.Extensions.Configuration
         /// Determines whether the source will be loaded if the underlying file changes.
         /// </summary>
         public bool ReloadOnChange { get; set; }
+
+        /// <summary>
+        /// Will be called if an uncaught exception occurs in FileConfigurationProvider.Load.
+        /// </summary>
+        public Action<Exception> OnLoadError { get; set; }
 
         /// <summary>
         /// Builds the <see cref="IConfigurationProvider"/> for this source.

--- a/src/Microsoft.Extensions.Configuration.FileExtensions/FileConfigurationSource.cs
+++ b/src/Microsoft.Extensions.Configuration.FileExtensions/FileConfigurationSource.cs
@@ -33,6 +33,12 @@ namespace Microsoft.Extensions.Configuration
         public bool ReloadOnChange { get; set; }
 
         /// <summary>
+        /// Number of milliseconds that reload will wait before calling Load.  This helps
+        /// avoid triggering reload before a file is completely written. Default is 250.
+        /// </summary>
+        public int ReloadDelay { get; set; } = 250;
+
+        /// <summary>
         /// Will be called if an uncaught exception occurs in FileConfigurationProvider.Load.
         /// </summary>
         public Action<FileLoadExceptionContext> OnLoadException { get; set; }

--- a/src/Microsoft.Extensions.Configuration.FileExtensions/FileConfigurationSource.cs
+++ b/src/Microsoft.Extensions.Configuration.FileExtensions/FileConfigurationSource.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Extensions.Configuration
         /// <summary>
         /// Will be called if an uncaught exception occurs in FileConfigurationProvider.Load.
         /// </summary>
-        public Action<Exception> OnLoadError { get; set; }
+        public Action<FileLoadExceptionContext> OnLoadException { get; set; }
 
         /// <summary>
         /// Builds the <see cref="IConfigurationProvider"/> for this source.

--- a/src/Microsoft.Extensions.Configuration.FileExtensions/FileLoadExceptionContext.cs
+++ b/src/Microsoft.Extensions.Configuration.FileExtensions/FileLoadExceptionContext.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Extensions.Configuration
+{
+    /// <summary>
+    /// Contains information about a file load exception.
+    /// </summary>
+    public class FileLoadExceptionContext
+    {
+        /// <summary>
+        /// The <see cref="FileConfigurationProvider"/> that caused the exception.
+        /// </summary>
+        public FileConfigurationProvider Provider { get; set; }
+
+        /// <summary>
+        /// The exception that occured in Load.
+        /// </summary>
+        public Exception Exception { get; set; }
+
+        /// <summary>
+        /// If true, the exception will not be rethrown.
+        /// </summary>
+        public bool Ignore { get; set; }
+    }
+}

--- a/src/Microsoft.Extensions.Configuration.FileExtensions/project.json
+++ b/src/Microsoft.Extensions.Configuration.FileExtensions/project.json
@@ -29,7 +29,8 @@
     },
     "netstandard1.3": {
       "dependencies": {
-        "System.AppContext": "4.1.0-*"
+        "System.AppContext": "4.1.0-*",
+        "System.Threading.Thread": "4.0.0-*"
       }
     }
   }

--- a/src/Microsoft.Extensions.Configuration.Ini/IniConfigurationSource.cs
+++ b/src/Microsoft.Extensions.Configuration.Ini/IniConfigurationSource.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Extensions.Configuration.Ini
         /// <returns>An <see cref="IniConfigurationProvider"/></returns>
         public override IConfigurationProvider Build(IConfigurationBuilder builder)
         {
-            FileProvider = FileProvider ?? builder.GetFileProvider();
+            EnsureDefaults(builder);
             return new IniConfigurationProvider(this);
         }
     }

--- a/src/Microsoft.Extensions.Configuration.Json/JsonConfigurationSource.cs
+++ b/src/Microsoft.Extensions.Configuration.Json/JsonConfigurationSource.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Extensions.Configuration.Json
         /// <returns>A <see cref="JsonConfigurationProvider"/></returns>
         public override IConfigurationProvider Build(IConfigurationBuilder builder)
         {
-            FileProvider = FileProvider ?? builder.GetFileProvider();
+            EnsureDefaults(builder);
             return new JsonConfigurationProvider(this);
         }
     }

--- a/src/Microsoft.Extensions.Configuration.Xml/XmlConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.Xml/XmlConfigurationProvider.cs
@@ -33,12 +33,12 @@ namespace Microsoft.Extensions.Configuration.Xml
             var data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
             var readerSettings = new XmlReaderSettings()
-                {
-                    CloseInput = false, // caller will close the stream
-                    DtdProcessing = DtdProcessing.Prohibit,
-                    IgnoreComments = true,
-                    IgnoreWhitespace = true
-                };
+            {
+                CloseInput = false, // caller will close the stream
+                DtdProcessing = DtdProcessing.Prohibit,
+                IgnoreComments = true,
+                IgnoreWhitespace = true
+            };
 
             using (var reader = Decryptor.CreateDecryptingXmlReader(stream, readerSettings))
             {

--- a/src/Microsoft.Extensions.Configuration.Xml/XmlConfigurationSource.cs
+++ b/src/Microsoft.Extensions.Configuration.Xml/XmlConfigurationSource.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.Configuration.Xml
         /// <returns>A <see cref="XmlConfigurationProvider"/></returns>
         public override IConfigurationProvider Build(IConfigurationBuilder builder)
         {
-            FileProvider = FileProvider ?? builder.GetFileProvider();
+            EnsureDefaults(builder);
             return new XmlConfigurationProvider(this);
         }
     }

--- a/test/Microsoft.Extensions.Configuration.FunctionalTests/ConfigurationTests.cs
+++ b/test/Microsoft.Extensions.Configuration.FunctionalTests/ConfigurationTests.cs
@@ -380,8 +380,13 @@ CommonKey3:CommonKey4=IniValue6";
             // Arrange
             File.WriteAllText(Path.Combine(_basePath, "error.json"), @"{""JsonKey1"": ");
 
+            FileConfigurationProvider provider = null;
             Exception jsonError = null;
-            Action<FileLoadExceptionContext> jsonLoadError = c => jsonError = c.Exception;
+            Action<FileLoadExceptionContext> jsonLoadError = c =>
+            {
+                jsonError = c.Exception;
+                provider = c.Provider;
+            };
 
             try
             {
@@ -393,6 +398,7 @@ CommonKey3:CommonKey4=IniValue6";
             {
                 Assert.Equal(e, jsonError);
             }
+            Assert.NotNull(provider);
         }
 
         [Fact]
@@ -401,13 +407,18 @@ CommonKey3:CommonKey4=IniValue6";
             // Arrange
             File.WriteAllText(Path.Combine(_basePath, "error.json"), @"{""JsonKey1"": ");
 
-            Action<FileLoadExceptionContext> jsonLoadError = c => c.Ignore = true;
+            FileConfigurationProvider provider = null;
+            Action<FileLoadExceptionContext> jsonLoadError = c =>
+            {
+                provider = c.Provider;
+                c.Ignore = true;
+            };
 
             new ConfigurationBuilder()
                 .Add(new JsonConfigurationSource { Path = "error.json", OnLoadException = jsonLoadError })
                 .Build();
 
-            Assert.True(true, "No exception thrown.");
+            Assert.NotNull(provider);
         }
 
         [Fact]

--- a/test/Microsoft.Extensions.Configuration.FunctionalTests/ConfigurationTests.cs
+++ b/test/Microsoft.Extensions.Configuration.FunctionalTests/ConfigurationTests.cs
@@ -519,6 +519,26 @@ IniKey1=IniValue2");
         }
 
         [Fact]
+        public async Task ReloadOnChangeWorksAfterError()
+        {
+            File.WriteAllText(Path.Combine(_basePath, "reload.json"), @"{""JsonKey1"": ""JsonValue1""}");
+            var config = new ConfigurationBuilder()
+                .AddJsonFile("reload.json", optional: false, reloadOnChange: true)
+                .Build();
+            Assert.Equal("JsonValue1", config["JsonKey1"]);
+
+            // Introduce an error and make sure the old key is removed
+            File.WriteAllText(Path.Combine(_basePath, "reload.json"), @"{""JsonKey1"": ");
+            await Task.Delay(2000); // wait for notification
+            Assert.Null(config["JsonKey1"]);
+
+            // Update the file again to make sure the config is updated
+            File.WriteAllText(Path.Combine(_basePath, "reload.json"), @"{""JsonKey1"": ""JsonValue2""}");
+            await Task.Delay(1100); // wait for notification
+            Assert.Equal("JsonValue2", config["JsonKey1"]);
+        }
+
+        [Fact]
         public void TouchingFileWillReload()
         {
             // Arrange
@@ -573,8 +593,7 @@ IniKey1=IniValue2");
             //Assert.True(token2.HasChanged, "Deleted");
         }
 
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.Linux)] // File watching is flaky on Linux CI
+        [Fact]
         public async Task CreatingOptionalFileInNonExistentDirectoryWillReload()
         {
             var directory = Path.Combine(_basePath, Path.GetRandomFileName());
@@ -602,7 +621,7 @@ IniKey1=IniValue2");
             File.WriteAllText(iniFile, @"IniKey1 = IniValue1");
             File.WriteAllText(xmlFile, @"<settings XmlKey1=""XmlValue1""/>");
 
-            await Task.Delay(2000);
+            await Task.Delay(1100);
 
             Assert.Equal("JsonValue1", config["JsonKey1"]);
             Assert.Equal("IniValue1", config["IniKey1"]);
@@ -641,7 +660,7 @@ IniKey1=IniValue2");
             File.Delete(iniFile);
             File.Delete(xmlFile);
 
-            await Task.Delay(2000);
+            await Task.Delay(1100);
 
             Assert.Null(config["JsonKey1"]);
             Assert.Null(config["IniKey1"]);
@@ -649,8 +668,7 @@ IniKey1=IniValue2");
             Assert.True(token.HasChanged);
         }
 
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.Linux)] // File watching is flaky on Linux CI
+        [Fact]
         public async Task CreatingWritingDeletingCreatingFileWillReload()
         {
             var iniFile = Path.Combine(_basePath, Path.GetRandomFileName());
@@ -674,7 +692,7 @@ IniKey1=IniValue2");
             File.WriteAllText(iniFile, @"IniKey1 = IniValue1");
             File.WriteAllText(xmlFile, @"<settings XmlKey1=""XmlValue1""/>");
 
-            await Task.Delay(2000);
+            await Task.Delay(1100);
 
             Assert.Equal("JsonValue1", config["JsonKey1"]);
             Assert.Equal("IniValue1", config["IniKey1"]);
@@ -687,7 +705,7 @@ IniKey1=IniValue2");
             File.WriteAllText(iniFile, @"IniKey1 = IniValue2");
             File.WriteAllText(xmlFile, @"<settings XmlKey1=""XmlValue2""/>");
 
-            await Task.Delay(2000);
+            await Task.Delay(1100);
 
             Assert.Equal("JsonValue2", config["JsonKey1"]);
             Assert.Equal("IniValue2", config["IniKey1"]);
@@ -702,7 +720,7 @@ IniKey1=IniValue2");
             File.Delete(iniFile);
             File.Delete(xmlFile);
 
-            await Task.Delay(2000);
+            await Task.Delay(1100);
 
             Assert.Null(config["JsonKey1"]);
             Assert.Null(config["IniKey1"]);
@@ -715,7 +733,7 @@ IniKey1=IniValue2");
             File.WriteAllText(iniFile, @"IniKey1 = IniValue1");
             File.WriteAllText(xmlFile, @"<settings XmlKey1=""XmlValue1""/>");
 
-            await Task.Delay(2000);
+            await Task.Delay(1100);
 
             Assert.Equal("JsonValue1", config["JsonKey1"]);
             Assert.Equal("IniValue1", config["IniKey1"]);

--- a/test/Microsoft.Extensions.Configuration.FunctionalTests/ConfigurationTests.cs
+++ b/test/Microsoft.Extensions.Configuration.FunctionalTests/ConfigurationTests.cs
@@ -261,17 +261,6 @@ CommonKey3:CommonKey4=IniValue6";
         }
 
         [Fact]
-        public void CanReadUnicodeString()
-        {
-            var configurationBuilder = new ConfigurationBuilder();
-            var fileJson = Path.Combine(_basePath, Path.GetRandomFileName());
-            File.WriteAllText(fileJson, @"{ ""SiteTitle"" : ""???""}");
-
-            var config = configurationBuilder.AddJsonFile(fileJson).Build();
-            Assert.Equal("???", config.GetSection("SiteTitle").Value);
-        }
-
-        [Fact]
         public void LoadAndCombineKeyValuePairsFromDifferentConfigurationProvidersWithAbsolutePath()
         {
             // Arrange
@@ -312,7 +301,6 @@ CommonKey3:CommonKey4=IniValue6";
 
             Assert.Equal("MemValue6", config["CommonKey1:CommonKey2:CommonKey3:CommonKey4"]);
         }
-
 
         [Fact]
         public void CanOverrideValuesWithNewConfigurationProvider()
@@ -383,6 +371,27 @@ CommonKey3:CommonKey4=IniValue6";
             {
                 Source.FileProvider = builder.GetFileProvider();
                 return this;
+            }
+        }
+
+        [Fact]
+        public void OnLoadErrorWillBeCalledOnParseError()
+        {
+            // Arrange
+            File.WriteAllText(Path.Combine(_basePath, "error.json"), @"{""JsonKey1"": ");
+
+            Exception jsonError = null;
+            Action<Exception> jsonLoadError = ex => jsonError = ex;
+
+            try
+            {
+                new ConfigurationBuilder()
+                    .Add(new JsonConfigurationSource { Path = "error.json", OnLoadError = jsonLoadError })
+                    .Build();
+            }
+            catch (FormatException e)
+            {
+                Assert.Equal(e, jsonError);
             }
         }
 

--- a/test/Microsoft.Extensions.Configuration.FunctionalTests/ConfigurationTests.cs
+++ b/test/Microsoft.Extensions.Configuration.FunctionalTests/ConfigurationTests.cs
@@ -381,18 +381,33 @@ CommonKey3:CommonKey4=IniValue6";
             File.WriteAllText(Path.Combine(_basePath, "error.json"), @"{""JsonKey1"": ");
 
             Exception jsonError = null;
-            Action<Exception> jsonLoadError = ex => jsonError = ex;
+            Action<FileLoadExceptionContext> jsonLoadError = c => jsonError = c.Exception;
 
             try
             {
                 new ConfigurationBuilder()
-                    .Add(new JsonConfigurationSource { Path = "error.json", OnLoadError = jsonLoadError })
+                    .Add(new JsonConfigurationSource { Path = "error.json", OnLoadException = jsonLoadError })
                     .Build();
             }
             catch (FormatException e)
             {
                 Assert.Equal(e, jsonError);
             }
+        }
+
+        [Fact]
+        public void OnLoadErrorCanIgnoreErrors()
+        {
+            // Arrange
+            File.WriteAllText(Path.Combine(_basePath, "error.json"), @"{""JsonKey1"": ");
+
+            Action<FileLoadExceptionContext> jsonLoadError = c => c.Ignore = true;
+
+            new ConfigurationBuilder()
+                .Add(new JsonConfigurationSource { Path = "error.json", OnLoadException = jsonLoadError })
+                .Build();
+
+            Assert.True(true, "No exception thrown.");
         }
 
         [Fact]

--- a/test/Microsoft.Extensions.Configuration.FunctionalTests/ConfigurationTests.cs
+++ b/test/Microsoft.Extensions.Configuration.FunctionalTests/ConfigurationTests.cs
@@ -375,7 +375,7 @@ CommonKey3:CommonKey4=IniValue6";
         }
 
         [Fact]
-        public void OnLoadErrorWillBeCalledOnParseError()
+        public void OnLoadErrorWillBeCalledOnJsonParseError()
         {
             // Arrange
             File.WriteAllText(Path.Combine(_basePath, "error.json"), @"{""JsonKey1"": ");
@@ -390,13 +390,68 @@ CommonKey3:CommonKey4=IniValue6";
 
             try
             {
-                new ConfigurationBuilder()
-                    .Add(new JsonConfigurationSource { Path = "error.json", OnLoadException = jsonLoadError })
+                new ConfigurationBuilder().AddJsonFile("error.json")
+                    .SetFileLoadExceptionHandler(jsonLoadError)
                     .Build();
             }
             catch (FormatException e)
             {
                 Assert.Equal(e, jsonError);
+            }
+            Assert.NotNull(provider);
+        }
+
+        [Fact]
+        public void OnLoadErrorWillBeCalledOnXmlParseError()
+        {
+            // Arrange
+            File.WriteAllText(Path.Combine(_basePath, "error.xml"), @"gobblygook");
+
+            FileConfigurationProvider provider = null;
+            Exception error = null;
+            Action<FileLoadExceptionContext> loadError = c =>
+            {
+                error = c.Exception;
+                provider = c.Provider;
+            };
+
+            try
+            {
+                new ConfigurationBuilder().AddJsonFile("error.xml")
+                    .SetFileLoadExceptionHandler(loadError)
+                    .Build();
+            }
+            catch (FormatException e)
+            {
+                Assert.Equal(e, error);
+            }
+            Assert.NotNull(provider);
+        }
+
+        [Fact]
+        public void OnLoadErrorWillBeCalledOnIniLoadError()
+        {
+            // Arrange
+            File.WriteAllText(Path.Combine(_basePath, "error.ini"), @"IniKey1=IniValue1
+IniKey1=IniValue2");
+
+            FileConfigurationProvider provider = null;
+            Exception error = null;
+            Action<FileLoadExceptionContext> loadError = c =>
+            {
+                error = c.Exception;
+                provider = c.Provider;
+            };
+
+            try
+            {
+                new ConfigurationBuilder().AddIniFile("error.ini")
+                    .SetFileLoadExceptionHandler(loadError)
+                    .Build();
+            }
+            catch (FormatException e)
+            {
+                Assert.Equal(e, error);
             }
             Assert.NotNull(provider);
         }


### PR DESCRIPTION
Fixes https://github.com/aspnet/Configuration/issues/489

No sugar currently: 

```C#
                Exception jsonError = null;
                Action<Exception> jsonLoadError = ex => jsonError = ex;
                new ConfigurationBuilder()
                    .Add(new JsonConfigurationSource { Path = "error.json", OnLoadError = jsonLoadError })
                    .Build();
```
This at least enables some way to see what failures are occuring during load/reload

@divega 