### PR TITLE
[Don't merge] PoC for Options-based AzureKeyVaultProvider

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureKeyVault/AzureKeyVaultConfigurationExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureKeyVault/AzureKeyVaultConfigurationExtensions.cs
@@ -3,10 +3,7 @@
 
 using System;
 using System.Security.Cryptography.X509Certificates;
-using System.Threading.Tasks;
-using Microsoft.Azure.KeyVault;
 using Microsoft.Extensions.Configuration.AzureKeyVault;
-using Microsoft.IdentityModel.Clients.ActiveDirectory;
 
 namespace Microsoft.Extensions.Configuration
 {
@@ -19,18 +16,20 @@ namespace Microsoft.Extensions.Configuration
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from the Azure KeyVault.
         /// </summary>
         /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
-        /// <param name="vault">The Azure KeyVault uri.</param>
+        /// <param name="vaultUri">The Azure KeyVault uri.</param>
         /// <param name="clientId">The application client id.</param>
         /// <param name="clientSecret">The client secret to use for authentication.</param>
-        /// <param name="filter">The predicate to filter secret entries before loading value, <code>null</code> to load all.</param>
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
         public static IConfigurationBuilder AddAzureKeyVault(
             this IConfigurationBuilder configurationBuilder,
-            string vault,
+            string vaultUri,
             string clientId,
-            string clientSecret,
-            Func<SecretItem, bool> filter)
+            string clientSecret)
         {
+            if (vaultUri == null)
+            {
+                throw new ArgumentNullException(nameof(vaultUri));
+            }
             if (clientId == null)
             {
                 throw new ArgumentNullException(nameof(clientId));
@@ -39,10 +38,15 @@ namespace Microsoft.Extensions.Configuration
             {
                 throw new ArgumentNullException(nameof(clientSecret));
             }
-            KeyVaultClient.AuthenticationCallback callback =
-                (authority, resource, scope) => GetTokenFromClientSecret(authority, resource, scope, clientId, clientSecret);
 
-            return configurationBuilder.AddAzureKeyVault(vault, callback, filter);
+            var options = new AzureKeyVaultOptions
+            {
+                VaultUri = vaultUri,
+                ClientId = clientId,
+                ClientSecret = clientSecret
+            };
+
+            return configurationBuilder.AddAzureKeyVault(options);
         }
 
 
@@ -50,18 +54,20 @@ namespace Microsoft.Extensions.Configuration
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from the Azure KeyVault.
         /// </summary>
         /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
-        /// <param name="vault">Azure KeyVault uri.</param>
+        /// <param name="vaultUri">Azure KeyVault uri.</param>
         /// <param name="clientId">The application client id.</param>
         /// <param name="certificate">The <see cref="X509Certificate2"/> to use for authentication.</param>
-        /// <param name="filter">The predicate to filter secret entries before loading value, <code>null</code> to load all.</param>
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
         public static IConfigurationBuilder AddAzureKeyVault(
             this IConfigurationBuilder configurationBuilder,
-            string vault,
+            string vaultUri,
             string clientId,
-            X509Certificate2 certificate,
-            Func<SecretItem, bool> filter)
+            X509Certificate2 certificate)
         {
+            if (vaultUri == null)
+            {
+                throw new ArgumentNullException(nameof(vaultUri));
+            }
             if (clientId == null)
             {
                 throw new ArgumentNullException(nameof(clientId));
@@ -70,83 +76,59 @@ namespace Microsoft.Extensions.Configuration
             {
                 throw new ArgumentNullException(nameof(certificate));
             }
-            KeyVaultClient.AuthenticationCallback callback =
-                (authority, resource, scope) => GetTokenFromClientCertificate(authority, resource, scope, clientId, certificate);
 
-            return configurationBuilder.AddAzureKeyVault(vault, callback, filter);
+            var options = new AzureKeyVaultOptions
+            {
+                VaultUri = vaultUri,
+                ClientId = clientId,
+                Certificate = certificate
+            };
+
+            return configurationBuilder.AddAzureKeyVault(options);
         }
 
         /// <summary>
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from the Azure KeyVault.
         /// </summary>
         /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
-        /// <param name="vault">Azure KeyVault uri.</param>
-        /// <param name="authenticationCallback">The <see cref="KeyVaultClient.AuthenticationCallback"/> to use for authentication.</param>
-        /// <param name="filter">The predicate to filter secret entries before loading value, <code>null</code> to load all.</param>
+        /// <param name="options">The options for retrieving values from the vault.</param>
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
         public static IConfigurationBuilder AddAzureKeyVault(
             this IConfigurationBuilder configurationBuilder,
-            string vault,
-            KeyVaultClient.AuthenticationCallback authenticationCallback,
-            Func<SecretItem, bool> filter)
+            IConfiguration options)
         {
-            if (authenticationCallback == null)
+            if (options == null)
             {
-                throw new ArgumentNullException(nameof(authenticationCallback));
+                throw new ArgumentNullException(nameof(options));
             }
-            return configurationBuilder.AddAzureKeyVault(vault, new KeyVaultClient(authenticationCallback), filter);
+
+            var keyVaultOptions = new AzureKeyVaultOptions();
+            options.Bind(keyVaultOptions);
+
+            return configurationBuilder.AddAzureKeyVault(keyVaultOptions);
         }
 
         /// <summary>
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from the Azure KeyVault.
         /// </summary>
         /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
-        /// <param name="vault">Azure KeyVault uri.</param>
-        /// <param name="client">The <see cref="KeyVaultClient"/> to use for retrieving values.</param>
-        /// <param name="filter">The predicate to filter secret entries before loading value, <code>null</code> to load all.</param>
+        /// <param name="options">The options for retrieving values from the vault.</param>
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
         public static IConfigurationBuilder AddAzureKeyVault(
             this IConfigurationBuilder configurationBuilder,
-            string vault,
-            KeyVaultClient client,
-            Func<SecretItem, bool> filter)
+            AzureKeyVaultOptions options)
         {
-            if (configurationBuilder == null)
+            if (options == null)
             {
-                throw new ArgumentNullException(nameof(configurationBuilder));
-            }
-            if (client == null)
-            {
-                throw new ArgumentNullException(nameof(client));
-            }
-            if (vault == null)
-            {
-                throw new ArgumentNullException(nameof(vault));
+                throw new ArgumentNullException(nameof(options));
             }
 
             configurationBuilder.Add(new AzureKeyVaultConfigurationSource()
             {
-                Client = client,
-                Vault = vault,
-                Filter = filter
+                Options = options
             });
 
             return configurationBuilder;
-        }
-
-        private static async Task<string> GetTokenFromClientSecret(string authority, string resource, string scope, string clientId, string clientSecret)
-        {
-            var authContext = new AuthenticationContext(authority);
-            var clientCred = new ClientCredential(clientId, clientSecret);
-            var result = await authContext.AcquireTokenAsync(resource, clientCred);
-            return result.AccessToken;
-        }
-
-        private static async Task<string> GetTokenFromClientCertificate(string authority, string resource, string scope, string clientId, X509Certificate2 certificate)
-        {
-            var authContext = new AuthenticationContext(authority);
-            var result = await authContext.AcquireTokenAsync(resource, new ClientAssertionCertificate(clientId, certificate));
-            return result.AccessToken;
         }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureKeyVault/AzureKeyVaultConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureKeyVault/AzureKeyVaultConfigurationProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Azure.KeyVault;
 
@@ -14,28 +15,39 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault
     public class AzureKeyVaultConfigurationProvider : ConfigurationProvider
     {
         private readonly IKeyVaultClient _client;
-        private readonly string _vault;
-        private readonly Func<SecretItem, bool> _filter;
+        private readonly string _vaultUri;
+        private readonly string _vaultName;
+        private readonly IDictionary<string, string> _includedSecrets;
+        private readonly IList<string> _excludedSecrets;
 
         /// <summary>
         /// Creates a new instance of <see cref="AzureKeyVaultConfigurationProvider"/>.
         /// </summary>
         /// <param name="client">The <see cref="KeyVaultClient"/> to use for retrieving values.</param>
-        /// <param name="vault">Azure KeyVault uri.</param>
-        /// <param name="filter">The predicate to filter secret entries before loading value, <code>null</code> to load all.</param>
-        public AzureKeyVaultConfigurationProvider(IKeyVaultClient client, string vault, Func<SecretItem, bool> filter)
+        /// <param name="vaultUri">Azure KeyVault uri.</param>
+        /// <param name="vaultName">An optional internal name for the vault.</param>
+        /// <param name="includedSecrets">Allows to only load the specified secrets.</param>
+        /// <param name="excludedSecrets">Allows to load all secrets except the ones specified here.</param>
+        public AzureKeyVaultConfigurationProvider(
+            IKeyVaultClient client, 
+            string vaultUri, 
+            string vaultName,
+            IDictionary<string, string> includedSecrets,
+            IList<string> excludedSecrets)
         {
             if (client == null)
             {
                 throw new ArgumentNullException(nameof(client));
             }
-            if (vault == null)
+            if (vaultUri == null)
             {
-                throw new ArgumentNullException(nameof(vault));
+                throw new ArgumentNullException(nameof(vaultUri));
             }
             _client = client;
-            _vault = vault;
-            _filter = filter;
+            _vaultUri = vaultUri;
+            _vaultName = vaultName;
+            _includedSecrets = includedSecrets ?? new Dictionary<string, string>();
+            _excludedSecrets = excludedSecrets ?? new List<string>();
         }
 
         /// <inheritdoc />
@@ -48,18 +60,81 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault
         {
             var data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-            var secrets = await _client.GetSecretsAsync(_vault);
+            if (_includedSecrets.Count > 0)
+            {
+                await LoadIncludedOnlyAsync(data);
+            }
+            else
+            {
+                await LoadAllExceptExcludedAsync(data);
+            }
+
+            Data = data;
+        }
+
+        private async Task LoadIncludedOnlyAsync(IDictionary<string, string> data)
+        {
+            // By convention, if there's only a key in the dictionary, 
+            // the actual Azure Key Vault secret name is equal to the internal name.
+            foreach (var kvp in _includedSecrets)
+            {
+                if (string.IsNullOrWhiteSpace(kvp.Value))
+                {
+                    _includedSecrets[kvp.Key] = kvp.Key;
+                }
+            }
+
+            // Swap dictionary to make sure every secret is loaded just once.
+            // Before: InternalSecret -> AzureSecretName
+            // After: AzureSecretName -> List<InternalSecret>
+            var transformedSecrets = _includedSecrets
+                .GroupBy(x => x.Value)
+                .ToDictionary(key => key.Key, element => element.Select(y => y.Key));
+
+            // loads all secrets in parallel.
+            var tasks = transformedSecrets.Select(x => LoadSecretIntoDataAsync(x.Key, x.Value, data)).ToList();
+            await Task.WhenAll(tasks);
+        }
+
+        private async Task  LoadSecretIntoDataAsync(
+            string secretName, 
+            IEnumerable<string> keys,
+            IDictionary<string, string> data)
+        {
+            var secret = await _client.GetSecretAsync(_vaultUri, secretName);
+
+            if (secret == null)
+            {
+                // TODO localize
+                throw new InvalidOperationException($"Secret '{secretName}' does not exist in key vault.");
+            }
+            if (string.IsNullOrWhiteSpace(secret.Value))
+            {
+                // TODO localize
+                throw new InvalidOperationException($"Secret '{secretName}' did not return a value.");
+            }
+
+            foreach (string key in keys)
+            {
+                data.Add(NormalizeKey(key), secret.Value);
+            }
+        }
+
+        private async Task LoadAllExceptExcludedAsync(IDictionary<string, string> data)
+        {
+            var secrets = await _client.GetSecretsAsync(_vaultUri);
             do
             {
                 foreach (var secretItem in secrets.Value)
                 {
-                    if (_filter?.Invoke(secretItem) == false)
+                    if (_excludedSecrets.Contains(secretItem.Identifier.Name))
                     {
                         continue;
                     }
 
+                    var key = NormalizeKey(secretItem.Identifier.Name);
                     var value = await _client.GetSecretAsync(secretItem.Id);
-                    var key = NormalizeKey(value.SecretIdentifier.Name);
+
                     data.Add(key, value.Value);
                 }
 
@@ -67,13 +142,19 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault
                     await _client.GetSecretsNextAsync(secrets.NextLink) :
                     null;
             } while (secrets != null);
-
-            Data = data;
         }
 
-        private static string NormalizeKey(string key)
+        private string NormalizeKey(string key)
         {
-            return key.Replace("__", ConfigurationPath.KeyDelimiter);
+            // Azure Key Vault does not allow the character ":" for secret names.
+            key = key.Replace("__", ConfigurationPath.KeyDelimiter);
+            
+            if (!string.IsNullOrWhiteSpace(_vaultName))
+            {
+                key = _vaultName + ConfigurationPath.KeyDelimiter + key;
+            }
+
+            return key;
         }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureKeyVault/AzureKeyVaultConfigurationSource.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureKeyVault/AzureKeyVaultConfigurationSource.cs
@@ -2,7 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
 using Microsoft.Azure.KeyVault;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
 
 namespace Microsoft.Extensions.Configuration.AzureKeyVault
 {
@@ -12,24 +15,75 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault
     public class AzureKeyVaultConfigurationSource : IConfigurationSource
     {
         /// <summary>
-        /// Gets or sets the <see cref="KeyVaultClient"/> to use for retrieving values.
+        /// Gets or sets the options required for retrieving values from the vault.
         /// </summary>
-        public KeyVaultClient Client { get; set; }
-
-        /// <summary>
-        /// Gets or sets the vault uri.
-        /// </summary>
-        public string Vault { get; set; }
-
-        /// <summary>
-        /// Gets or sets The predicate to filter secret entries before loading value, <code>null</code> to load all.
-        /// </summary>
-        public Func<SecretItem, bool> Filter { get; set; }
+        public AzureKeyVaultOptions Options { get; set; }
 
         /// <inheritdoc />
         public IConfigurationProvider Build(IConfigurationBuilder builder)
         {
-            return new AzureKeyVaultConfigurationProvider(new KeyVaultClientWrapper(Client), Vault, Filter);
+            if (Options == null)
+            {
+                throw new ArgumentNullException(nameof(Options));
+            }
+            if (Options.ClientId == null)
+            {
+                throw new ArgumentNullException(nameof(Options.ClientId));
+            }
+            if (string.IsNullOrWhiteSpace(Options.VaultUri))
+            {
+                throw new ArgumentNullException(nameof(Options.VaultUri));
+            }
+
+            var keyVaultClient = CreateKeyVaultClient(Options);
+
+            return new AzureKeyVaultConfigurationProvider(
+                new KeyVaultClientWrapper(keyVaultClient), 
+                Options.VaultUri,
+                Options.VaultName,
+                Options.IncludedSecrets,
+                Options.ExcludedSecrets);
+        }
+
+        private KeyVaultClient CreateKeyVaultClient(AzureKeyVaultOptions options)
+        {
+            KeyVaultClient.AuthenticationCallback callback = null;
+
+            if (!string.IsNullOrWhiteSpace(Options.ClientSecret))
+            {
+                callback = (authority, resource, scope) => GetTokenFromClientSecret(authority, resource, scope, Options.ClientId, Options.ClientSecret);
+            }
+            else if (Options.Certificate != null)
+            {
+                callback = (authority, resource, scope) => GetTokenFromClientCertificate(authority, resource, scope, Options.ClientId, Options.Certificate);
+            }
+            else if (!string.IsNullOrWhiteSpace(Options.Thumbprint))
+            {
+                // TODO validate other options
+                // TODO load certificate based on options
+                throw new NotImplementedException();
+            }
+            else
+            {
+                throw new ArgumentNullException(nameof(Options.ClientSecret));
+            }
+
+            return new KeyVaultClient(callback);
+        }
+
+        private static async Task<string> GetTokenFromClientSecret(string authority, string resource, string scope, string clientId, string clientSecret)
+        {
+            var authContext = new AuthenticationContext(authority);
+            var clientCred = new ClientCredential(clientId, clientSecret);
+            var result = await authContext.AcquireTokenAsync(resource, clientCred);
+            return result.AccessToken;
+        }
+
+        private static async Task<string> GetTokenFromClientCertificate(string authority, string resource, string scope, string clientId, X509Certificate2 certificate)
+        {
+            var authContext = new AuthenticationContext(authority);
+            var result = await authContext.AcquireTokenAsync(resource, new ClientAssertionCertificate(clientId, certificate));
+            return result.AccessToken;
         }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.AzureKeyVault/AzureKeyVaultOptions.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureKeyVault/AzureKeyVaultOptions.cs
@@ -1,0 +1,75 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Microsoft.Extensions.Configuration.AzureKeyVault
+{
+    /// <summary>
+    /// Options for retrieving secrets from a Key Vault.
+    /// </summary>
+    public class AzureKeyVaultOptions
+    {
+        // TODO delimiter?
+
+        /// <summary>
+        /// The application client id.
+        /// </summary>
+        public string ClientId { get; set; }
+
+        /// <summary>
+        /// Authentication via a client secret.
+        /// </summary>
+        public string ClientSecret { get; set; }
+
+        /// <summary>
+        /// Authentication via an already loaded client certificate.
+        /// </summary>
+        public X509Certificate2 Certificate { get; set; }
+
+        /// <summary>
+        /// Authentication via a client certificate with the given <see cref="Thumbprint" /> that should be loaded
+        /// from the given <see cref="StoreLocation" /> and <see cref="StoreName" />.
+        /// </summary>
+        public string Thumbprint { get; set; }
+
+        /// <summary>
+        /// Authentication via a client certificate with the given <see cref="Thumbprint" /> that should be loaded
+        /// from the given <see cref="StoreLocation" /> and <see cref="StoreName" />.
+        /// </summary>
+        public StoreLocation? StoreLocation { get; set; }
+
+        /// <summary>
+        /// Authentication via a client certificate with the given <see cref="Thumbprint" /> that should be loaded
+        /// from the given <see cref="StoreLocation" /> and <see cref="StoreName" />.
+        /// </summary>
+        public StoreName? StoreName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the vault uri.
+        /// </summary>
+        public string VaultUri { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional internal name for the vault.
+        /// Will be used as a path-prefix for all secrets.
+        /// </summary>
+        public string VaultName { get; set; }
+
+        /// <summary>
+        /// <para>Allows to only load the specified secrets.
+        /// This also allows to write mappings between internal names and key vault names.</para>
+        /// </summary>
+        /// <remarks>
+        /// Key: Internal name for the secret.
+        /// Value: Name of the secret in Azure Key Vault. (leave empty if equal to internal name)
+        /// </remarks>
+        public Dictionary<string, string> IncludedSecrets { get; set; }
+
+        /// <summary>
+        /// Allows to load all secrets except the ones specified here.
+        /// </summary>
+        public List<string> ExcludedSecrets { get; set; }
+    }
+}

--- a/src/Microsoft.Extensions.Configuration.AzureKeyVault/IKeyVaultClient.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureKeyVault/IKeyVaultClient.cs
@@ -14,14 +14,20 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault
     public interface IKeyVaultClient
     {
         /// <summary>List secrets in the specified vault</summary>
-        /// <param name="vault">The URL for the vault containing the secrets.</param>
+        /// <param name="vaultUri">The URL for the vault containing the secrets.</param>
         /// <returns>A response message containing a list of secrets in the vault along with a link to the next page of secrets</returns>
-        Task<ListSecretsResponseMessage> GetSecretsAsync(string vault);
+        Task<ListSecretsResponseMessage> GetSecretsAsync(string vaultUri);
 
-        /// <summary>Gets a secret.</summary>
+        /// <summary>Gets a secret by identifier.</summary>
         /// <param name="secretIdentifier">The URL for the secret.</param>
         /// <returns>A response message containing the secret</returns>
         Task<Secret> GetSecretAsync(string secretIdentifier);
+
+        /// <summary>Gets a secret by name.</summary>
+        /// <param name="vaultUri">The URL for the vault containing the secrets.</param>
+        /// <param name="secretName">The name for the secret.</param>
+        /// <returns>A response message containing the secret</returns>
+        Task<Secret> GetSecretAsync(string vaultUri, string secretName);
 
         /// <summary>List the next page of secrets</summary>
         /// <param name="nextLink">nextLink value from a previous call to GetSecrets or GetSecretsNext</param>

--- a/src/Microsoft.Extensions.Configuration.AzureKeyVault/KeyVaultClientWrapper.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureKeyVault/KeyVaultClientWrapper.cs
@@ -33,6 +33,12 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault
         }
 
         /// <inheritdoc />
+        public Task<Secret> GetSecretAsync(string vaultUri, string secretName)
+        {
+            return _keyVaultClientImplementation.GetSecretAsync(vaultUri, secretName);
+        }
+
+        /// <inheritdoc />
         public Task<ListSecretsResponseMessage> GetSecretsNextAsync(string nextLink)
         {
             return _keyVaultClientImplementation.GetSecretsNextAsync(nextLink);

--- a/src/Microsoft.Extensions.Configuration.AzureKeyVault/project.json
+++ b/src/Microsoft.Extensions.Configuration.AzureKeyVault/project.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "Microsoft.Extensions.Configuration": "1.1.0-*",
+    "Microsoft.Extensions.Configuration.Binder": "1.1.0-*",
     "Microsoft.Extensions.Configuration.FileExtensions": "1.1.0-*",
     "Microsoft.IdentityModel.Clients.ActiveDirectory": "3.13.4",
     "Microsoft.Azure.KeyVault": "1.0.0"


### PR DESCRIPTION
Hi @pakrym, @glennc,
I took the existing #500 PR and integrated some of our current in-house solution (as described in [my comment](https://github.com/aspnet/Configuration/issues/487#issuecomment-241670217) in #487) into it. 

**This is a completely untested quick & dirty PoC (the tests don't even compile and some stuff is not yet implemented)**. I just wanted to show you something with as little effort as possible in case you don't want to proceed with such a solution.

Differences to the existing PR:
* Parameters are Options-based - this means, they can come from a different ConfigurationBuilder (e.g. from a file, from environment variables, ...)
* Include-Pattern which allows to map one physical secret to multiple internal keys
* The internal keys can contain a ":" which allows for nice nesting if stuff should be mapped e.g. to multiple Options-classes.
* Exclude-Pattern for people who just want to load all secrets except some 
* If there's no include-pattern and no exclude-pattern, every secret is loaded
* It does not handle multiple vaults right now. Not sure if this is required or if people should just call .AddAzureKeyVault() multiple times.
* Vault-name alias: If added to an existing ConfigurationBuilder, one could specify an internal name for the vault which will be added as a prefix to every key in the dictionary (e.g. "MyVault:SomeKey", "MyVault:SomeOtherKey")

A config file which just fetches every secret without a mapping would look like this:
```json
{
  "ClientId": "75e92952-701b-43f7-9f8b-8769bdd804de",
  "ClientSecret": "a909502dd82ae41433e6f83886b00d4277a32a7b",
  "VaultUri": "https://my-vault.vault.azure.net"
}
```

A config file with an include pattern would look like this:
```json
{
  "ClientId": "75e92952-701b-43f7-9f8b-8769bdd804de",
  "Thumbprint": "a909502dd82ae41433e6f83886b00d4277a32a7b",
  "StoreLocation": "LocalMachine",
  "VaultName": "MyVault",
  "VaultUri": "https://my-vault.vault.azure.net",
  "IncludedSecrets": {
    "KeyWithNoDifference": "",
    "KeyWithDifference": "ActualKeyIsDifferent",
    "ModuleOneOptions:ConnectionString": "Sql-ConnectionString",
    "ModuleTwoOptions:SqlConnectionString": "Sql-ConnectionString",
  }
}
```

If you decide to go with such a solution, I'd be happy to improve the code and follow your guidance!!