### PR TITLE
Return of Get<T> (RIP Bind<T>)

### DIFF
--- a/src/Microsoft.Extensions.Configuration.Binder/ConfigurationBinder.cs
+++ b/src/Microsoft.Extensions.Configuration.Binder/ConfigurationBinder.cs
@@ -16,6 +16,47 @@ namespace Microsoft.Extensions.Configuration
     public static class ConfigurationBinder
     {
         /// <summary>
+        /// Attempts to bind the configuration instance to a new instance of type T.
+        /// If this configuration section has a value, that will be used.
+        /// Otherwise binding by matching property names against configuration keys recursively.
+        /// </summary>
+        /// <typeparam name="T">The type of the new instance to bind.</typeparam>
+        /// <param name="configuration">The configuration instance to bind.</param>
+        /// <returns>The new instance of T if successful, default(T) otherwise.</returns>
+        public static T Get<T>(this IConfiguration configuration)
+        {
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            var result = configuration.Get(typeof(T));
+            if (result == null)
+            {
+                return default(T);
+            }
+            return (T)result;
+        }
+
+        /// <summary>
+        /// Attempts to bind the configuration instance to a new instance of type T.
+        /// If this configuration section has a value, that will be used.
+        /// Otherwise binding by matching property names against configuration keys recursively.
+        /// </summary>
+        /// <param name="configuration">The configuration instance to bind.</param>
+        /// <param name="type">The type of the new instance to bind.</param>
+        /// <returns>The new instance if successful, null otherwise.</returns>
+        public static object Get(this IConfiguration configuration, Type type)
+        {
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            return BindInstance(type, instance: null, config: configuration);
+        }
+
+        /// <summary>
         /// Attempts to bind the given object instance to configuration values by matching property names against configuration keys recursively.
         /// </summary>
         /// <param name="configuration">The configuration instance to bind.</param>
@@ -31,24 +72,6 @@ namespace Microsoft.Extensions.Configuration
             {
                 BindInstance(instance.GetType(), instance, configuration);
             }
-        }
-
-        /// <summary>
-        /// Attempts to bind a new instance of T to configuration values by matching property names against configuration keys recursively.
-        /// </summary>
-        /// <typeparam name="T">The type of the new instance to bind.</typeparam>
-        /// <param name="configuration">The configuration instance to bind.</param>
-        /// <returns>The new instance of T</returns>
-        public static T Bind<T>(this IConfiguration configuration) where T : new()
-        {
-            if (configuration == null)
-            {
-                throw new ArgumentNullException(nameof(configuration));
-            }
-
-            var instance = new T();
-            BindInstance(instance.GetType(), instance, configuration);
-            return instance;
         }
 
         /// <summary>

--- a/test/Microsoft.Extensions.Configuration.Binder.Test/ConfigurationBinderTests.cs
+++ b/test/Microsoft.Extensions.Configuration.Binder.Test/ConfigurationBinderTests.cs
@@ -497,6 +497,26 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             Assert.Equal("other stuff", ComplexOptions.StaticProperty);
         }
 
+        [Fact]
+        public void CanGetComplexOptionsWhichHasAlsoHasValue()
+        {
+            var dic = new Dictionary<string, string>
+            {
+                {"obj", "whut" },
+                {"obj:Integer", "-2"},
+                {"obj:Boolean", "TRUe"},
+                {"obj:Nested:Integer", "11"}
+            };
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(dic);
+            var config = configurationBuilder.Build();
+
+            var options = config.GetSection("obj").Get<ComplexOptions>();
+            Assert.True(options.Boolean);
+            Assert.Equal(-2, options.Integer);
+            Assert.Equal(11, options.Nested.Integer);
+        }
+
         [Theory]
         [InlineData("ReadOnly")]
         [InlineData("PrivateSetter")]

--- a/test/Microsoft.Extensions.Configuration.Binder.Test/ConfigurationBinderTests.cs
+++ b/test/Microsoft.Extensions.Configuration.Binder.Test/ConfigurationBinderTests.cs
@@ -222,20 +222,6 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
         }
 
         [Fact]
-        public void GetThrowsOnBadInteger()
-        {
-            var dic = new Dictionary<string, string>
-            {
-                {"NotNumber", "gib"}
-            };
-            var configurationBuilder = new ConfigurationBuilder();
-            configurationBuilder.AddInMemoryCollection(dic);
-            var config = configurationBuilder.Build();
-
-            Assert.Equal(0, config.GetValue<int>("Integer"));
-        }
-
-        [Fact]
         public void GetDefaultsWhenDataDoesNotExist()
         {
             var dic = new Dictionary<string, string>


### PR DESCRIPTION
- Bind<T> morphing back into Get<T>
- T Get<T>() + object Get(Type type)

Initial starting point for PR is what we had before minus the overloads for default values and sugar for specifying a sectionName, where Value is used if specified, otherwise children are bound. (uses the bind logic exactly) 

@divega I know you have some ideas around what this should do instead, what did you have in mind?

cc @glennc 
