### PR TITLE
Add AddUserSecrets<TStartup>()

### DIFF
--- a/src/Microsoft.Extensions.Configuration.UserSecrets/ConfigurationExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.UserSecrets/ConfigurationExtensions.cs
@@ -17,8 +17,19 @@ namespace Microsoft.Extensions.Configuration
         private const string Secrets_File_Name = "secrets.json";
 
         /// <summary>
+        /// Adds the user secrets configuration source. Searches the assembly that contains type <typeparamref name="T"/>
+        /// for an instance of <see cref="UserSecretsIdAttribute"/>.
+        /// </summary>
+        /// <param name="configuration"></param>
+        /// <typeparam name="T">The type from the assembly to search for an instance of <see cref="UserSecretsIdAttribute"/>.</typeparam>
+        /// <returns></returns>
+        public static IConfigurationBuilder AddUserSecrets<T>(this IConfigurationBuilder configuration)
+            where T : class
+            => configuration.AddUserSecrets(typeof(T).GetTypeInfo().Assembly);
+
+        /// <summary>
         /// Adds the user secrets configuration source. Searches the assembly from <see cref="Assembly.GetEntryAssembly"/>
-        /// for an instance of <see cref="UserSecretsIdAttribute"/>
+        /// for an instance of <see cref="UserSecretsIdAttribute"/>.
         /// </summary>
         /// <param name="configuration"></param>
         /// <returns></returns>
@@ -30,6 +41,12 @@ namespace Microsoft.Extensions.Configuration
             }
 
             var entryAssembly = Assembly.GetEntryAssembly();
+            if (entryAssembly == null)
+            {
+                // can occur inside an app domain
+                throw new InvalidOperationException(Resources.Error_EntryAssemblyNull);
+            }
+
             var attribute = entryAssembly.GetCustomAttribute<UserSecretsIdAttribute>();
             if (attribute != null)
             {

--- a/src/Microsoft.Extensions.Configuration.UserSecrets/Properties/Resources.Designer.cs
+++ b/src/Microsoft.Extensions.Configuration.UserSecrets/Properties/Resources.Designer.cs
@@ -27,6 +27,22 @@ namespace Microsoft.Extensions.Configuration.UserSecrets
         }
 
         /// <summary>
+        /// This method could not find a user secret ID because the application's entry assembly is not set. Try using the ".AddUserSecrets(Assembly assembly)" method instead.
+        /// </summary>
+        internal static string Error_EntryAssemblyNull
+        {
+            get { return GetString("Error_EntryAssemblyNull"); }
+        }
+
+        /// <summary>
+        /// This method could not find a user secret ID because the application's entry assembly is not set. Try using the ".AddUserSecrets(Assembly assembly)" method instead.
+        /// </summary>
+        internal static string FormatError_EntryAssemblyNull()
+        {
+            return GetString("Error_EntryAssemblyNull");
+        }
+
+        /// <summary>
         /// Invalid character '{0}' found in 'userSecretsId' value at index '{1}'.
         /// </summary>
         internal static string Error_Invalid_Character_In_UserSecrets_Id

--- a/src/Microsoft.Extensions.Configuration.UserSecrets/Resources.resx
+++ b/src/Microsoft.Extensions.Configuration.UserSecrets/Resources.resx
@@ -120,6 +120,9 @@
   <data name="Common_StringNullOrEmpty" xml:space="preserve">
     <value>Value cannot be null or an empty string.</value>
   </data>
+  <data name="Error_EntryAssemblyNull" xml:space="preserve">
+    <value>This method could not find a user secret ID because the application's entry assembly is not set. Try using the ".AddUserSecrets(Assembly assembly)" method instead.</value>
+  </data>
   <data name="Error_Invalid_Character_In_UserSecrets_Id" xml:space="preserve">
     <value>Invalid character '{0}' found in 'userSecretsId' value at index '{1}'.</value>
   </data>

--- a/test/Microsoft.Extensions.Configuration.UserSecrets.Test/ConfigurationExtensionTest.cs
+++ b/test/Microsoft.Extensions.Configuration.UserSecrets.Test/ConfigurationExtensionTest.cs
@@ -66,6 +66,21 @@ namespace Microsoft.Extensions.Configuration.UserSecrets.Test
             Assert.Equal(randValue, config[configKey]);
         }
 
+
+        [Fact]
+        public void AddUserSecrets_FindsAssemblyAttributeFromType()
+        {
+            var randValue = Guid.NewGuid().ToString();
+            var configKey = "MyDummySetting";
+
+            SetSecret(UserSecretsTestFixture.TestSecretsId, configKey, randValue);
+            var config = new ConfigurationBuilder()
+                .AddUserSecrets<ConfigurationExtensionTest>()
+                .Build();
+
+            Assert.Equal(randValue, config[configKey]);
+        }
+
         [Fact]
         public void AddUserSecrets_ShowsAssemblyAttributeError_When_ProjectJson_Missing()
         {


### PR DESCRIPTION
Mitigates #543. A full fix requires templates to start using this overload instead of `.AddUserSecrets()`.

Also fixes the NRE for null entry assemblies to be more user-friendly.
