### PR TITLE
Bump test projects up to .NET 4.5.2

### DIFF
--- a/test/Microsoft.Extensions.Configuration.AzureKeyVault.Test/Microsoft.Extensions.Configuration.AzureKeyVault.Test.csproj
+++ b/test/Microsoft.Extensions.Configuration.AzureKeyVault.Test/Microsoft.Extensions.Configuration.AzureKeyVault.Test.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFramework>net451</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Extensions.Configuration.Binder.Test/Microsoft.Extensions.Configuration.Binder.Test.csproj
+++ b/test/Microsoft.Extensions.Configuration.Binder.Test/Microsoft.Extensions.Configuration.Binder.Test.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Extensions.Configuration.Binder\Microsoft.Extensions.Configuration.Binder.csproj" />

--- a/test/Microsoft.Extensions.Configuration.CommandLine.Test/Microsoft.Extensions.Configuration.CommandLine.Test.csproj
+++ b/test/Microsoft.Extensions.Configuration.CommandLine.Test/Microsoft.Extensions.Configuration.CommandLine.Test.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Extensions.Configuration.CommandLine\Microsoft.Extensions.Configuration.CommandLine.csproj" />

--- a/test/Microsoft.Extensions.Configuration.DockerSecrets.Test/Microsoft.Extensions.Configuration.DockerSecrets.Test.csproj
+++ b/test/Microsoft.Extensions.Configuration.DockerSecrets.Test/Microsoft.Extensions.Configuration.DockerSecrets.Test.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Extensions.Configuration.EnvironmentVariables.Test/Microsoft.Extensions.Configuration.EnvironmentVariables.Test.csproj
+++ b/test/Microsoft.Extensions.Configuration.EnvironmentVariables.Test/Microsoft.Extensions.Configuration.EnvironmentVariables.Test.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Extensions.Configuration.EnvironmentVariables\Microsoft.Extensions.Configuration.EnvironmentVariables.csproj" />

--- a/test/Microsoft.Extensions.Configuration.FileExtensions.Test/Microsoft.Extensions.Configuration.FileExtensions.Test.csproj
+++ b/test/Microsoft.Extensions.Configuration.FileExtensions.Test/Microsoft.Extensions.Configuration.FileExtensions.Test.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Extensions.Configuration.FileExtensions\Microsoft.Extensions.Configuration.FileExtensions.csproj" />

--- a/test/Microsoft.Extensions.Configuration.FunctionalTests/ArrayTests.cs
+++ b/test/Microsoft.Extensions.Configuration.FunctionalTests/ArrayTests.cs
@@ -101,7 +101,7 @@ i=ini_i.i.i.i
 
         public ArrayTests()
         {
-#if NET451
+#if NET452
             var basePath = AppDomain.CurrentDomain.GetData("APP_CONTEXT_BASE_DIRECTORY") as string ??
                 AppDomain.CurrentDomain.BaseDirectory ??
                 string.Empty;

--- a/test/Microsoft.Extensions.Configuration.FunctionalTests/ConfigurationTests.cs
+++ b/test/Microsoft.Extensions.Configuration.FunctionalTests/ConfigurationTests.cs
@@ -78,7 +78,7 @@ CommonKey3:CommonKey4=IniValue6";
         {
             _fileSystem = new DisposableFileSystem();
             _fileProvider = new PhysicalFileProvider(_fileSystem.RootPath);
-#if NET451
+#if NET452
             _basePath = AppDomain.CurrentDomain.GetData("APP_CONTEXT_BASE_DIRECTORY") as string ??
                 AppDomain.CurrentDomain.BaseDirectory ??
                 string.Empty;

--- a/test/Microsoft.Extensions.Configuration.FunctionalTests/Microsoft.Extensions.Configuration.FunctionalTests.csproj
+++ b/test/Microsoft.Extensions.Configuration.FunctionalTests/Microsoft.Extensions.Configuration.FunctionalTests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Extensions.Configuration.Ini\Microsoft.Extensions.Configuration.Ini.csproj" />

--- a/test/Microsoft.Extensions.Configuration.Ini.Test/Microsoft.Extensions.Configuration.Ini.Test.csproj
+++ b/test/Microsoft.Extensions.Configuration.Ini.Test/Microsoft.Extensions.Configuration.Ini.Test.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Extensions.Configuration.Ini\Microsoft.Extensions.Configuration.Ini.csproj" />

--- a/test/Microsoft.Extensions.Configuration.Json.Test/Microsoft.Extensions.Configuration.Json.Test.csproj
+++ b/test/Microsoft.Extensions.Configuration.Json.Test/Microsoft.Extensions.Configuration.Json.Test.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Extensions.Configuration.Json\Microsoft.Extensions.Configuration.Json.csproj" />

--- a/test/Microsoft.Extensions.Configuration.Test.Common/Microsoft.Extensions.Configuration.Test.Common.csproj
+++ b/test/Microsoft.Extensions.Configuration.Test.Common/Microsoft.Extensions.Configuration.Test.Common.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.5</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Extensions.Configuration.Test/Microsoft.Extensions.Configuration.Test.csproj
+++ b/test/Microsoft.Extensions.Configuration.Test/Microsoft.Extensions.Configuration.Test.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452/TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Extensions.Configuration.FileExtensions\Microsoft.Extensions.Configuration.FileExtensions.csproj" />

--- a/test/Microsoft.Extensions.Configuration.Test/Microsoft.Extensions.Configuration.Test.csproj
+++ b/test/Microsoft.Extensions.Configuration.Test/Microsoft.Extensions.Configuration.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net452/TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>

--- a/test/Microsoft.Extensions.Configuration.Xml.Test/Microsoft.Extensions.Configuration.Xml.Test.csproj
+++ b/test/Microsoft.Extensions.Configuration.Xml.Test/Microsoft.Extensions.Configuration.Xml.Test.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Extensions.Configuration.Test.Common\Microsoft.Extensions.Configuration.Test.Common.csproj" />
@@ -11,7 +12,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Testing" Version="1.2.0-*" />
     <PackageReference Include="xunit" Version="2.2.0-*" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System.Security" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
- aspnet/Testing#248
- xUnit no longer supports .NET 4.5.1
- build tests for desktop .NET only on Windows
  - except Microsoft.Extensions.Configuration.AzureKeyVault.Test project; that will be handled differently