### PR TITLE
Check if AppVeyor image has .NET 4.6.2 installed

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,4 +12,4 @@ clone_depth: 1
 test: off
 deploy: off
 # Required for dotnet-test to work
-os: Visual Studio 2015
+os: Visual Studio 2017 RC


### PR DESCRIPTION
Do not merge. Just testing which .NET framework version is installed on the AppVeyor VS 2017 RC image.