### PR TITLE
Fix minor XML comment typos

### DIFF
--- a/src/Microsoft.Extensions.Configuration.Abstractions/IConfigurationBuilder.cs
+++ b/src/Microsoft.Extensions.Configuration.Abstractions/IConfigurationBuilder.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Extensions.Configuration
         Dictionary<string, object> Properties { get; }
 
         /// <summary>
-        /// Gets the sources used to obtain configuation values
+        /// Gets the sources used to obtain configuration values
         /// </summary>
         IEnumerable<IConfigurationSource> Sources { get; }
 

--- a/src/Microsoft.Extensions.Configuration/ConfigurationBuilder.cs
+++ b/src/Microsoft.Extensions.Configuration/ConfigurationBuilder.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Extensions.Configuration
         private readonly IList<IConfigurationSource> _sources = new List<IConfigurationSource>();
 
         /// <summary>
-        /// Returns the sources used to obtain configuation values.
+        /// Returns the sources used to obtain configuration values.
         /// </summary>
         public IEnumerable<IConfigurationSource> Sources
         {


### PR DESCRIPTION
Fixes two occurrences of the word "configuation" in both the IConfigurationBuilder interface and the implementation ConfigurationBuilder class XML documentation comments.