### PR TITLE
UserSecrets: remove build warning and tweak runtime error

### DIFF
--- a/src/Microsoft.Extensions.Configuration.UserSecrets/Properties/Resources.Designer.cs
+++ b/src/Microsoft.Extensions.Configuration.UserSecrets/Properties/Resources.Designer.cs
@@ -15,52 +15,46 @@ namespace Microsoft.Extensions.Configuration.UserSecrets
         /// </summary>
         internal static string Common_StringNullOrEmpty
         {
-            get { return GetString("Common_StringNullOrEmpty"); }
+            get => GetString("Common_StringNullOrEmpty");
         }
 
         /// <summary>
         /// Value cannot be null or an empty string.
         /// </summary>
         internal static string FormatCommon_StringNullOrEmpty()
-        {
-            return GetString("Common_StringNullOrEmpty");
-        }
+            => GetString("Common_StringNullOrEmpty");
 
         /// <summary>
         /// Invalid character '{0}' found in the user secrets ID at index '{1}'.
         /// </summary>
         internal static string Error_Invalid_Character_In_UserSecrets_Id
         {
-            get { return GetString("Error_Invalid_Character_In_UserSecrets_Id"); }
+            get => GetString("Error_Invalid_Character_In_UserSecrets_Id");
         }
 
         /// <summary>
         /// Invalid character '{0}' found in the user secrets ID at index '{1}'.
         /// </summary>
         internal static string FormatError_Invalid_Character_In_UserSecrets_Id(object p0, object p1)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("Error_Invalid_Character_In_UserSecrets_Id"), p0, p1);
-        }
+            => string.Format(CultureInfo.CurrentCulture, GetString("Error_Invalid_Character_In_UserSecrets_Id"), p0, p1);
 
         /// <summary>
         /// Could not find 'UserSecretsIdAttribute' on assembly '{0}'.
-        /// Check that the project for '{0}' has set the property 'UserSecretsId' and
-        /// that the project references the Microsoft.Extensions.Configuration.UserSecrets package.
+        /// Check that the project for '{0}' has set the 'UserSecretsId' build property.
+        /// If the 'UserSecretsId' property is already set then add a reference to the Microsoft.Extensions.Configuration.UserSecrets package.
         /// </summary>
         internal static string Error_Missing_UserSecretsIdAttribute
         {
-            get { return GetString("Error_Missing_UserSecretsIdAttribute"); }
+            get => GetString("Error_Missing_UserSecretsIdAttribute");
         }
 
         /// <summary>
         /// Could not find 'UserSecretsIdAttribute' on assembly '{0}'.
-        /// Check that the project for '{0}' has set the property 'UserSecretsId' and
-        /// that the project references the Microsoft.Extensions.Configuration.UserSecrets package.
+        /// Check that the project for '{0}' has set the 'UserSecretsId' build property.
+        /// If the 'UserSecretsId' property is already set then add a reference to the Microsoft.Extensions.Configuration.UserSecrets package.
         /// </summary>
         internal static string FormatError_Missing_UserSecretsIdAttribute(object p0)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("Error_Missing_UserSecretsIdAttribute"), p0);
-        }
+            => string.Format(CultureInfo.CurrentCulture, GetString("Error_Missing_UserSecretsIdAttribute"), p0);
 
         private static string GetString(string name, params string[] formatterNames)
         {

--- a/src/Microsoft.Extensions.Configuration.UserSecrets/Resources.resx
+++ b/src/Microsoft.Extensions.Configuration.UserSecrets/Resources.resx
@@ -125,7 +125,7 @@
   </data>
   <data name="Error_Missing_UserSecretsIdAttribute" xml:space="preserve">
     <value>Could not find 'UserSecretsIdAttribute' on assembly '{0}'.
-Check that the project for '{0}' has set the property 'UserSecretsId' and
-that the project references the Microsoft.Extensions.Configuration.UserSecrets package.</value>
+Check that the project for '{0}' has set the 'UserSecretsId' build property.
+If the 'UserSecretsId' property is already set then add a reference to the Microsoft.Extensions.Configuration.UserSecrets package.</value>
   </data>
 </root>

--- a/src/Microsoft.Extensions.Configuration.UserSecrets/build/GenerateUserSecretsAttribute.targets
+++ b/src/Microsoft.Extensions.Configuration.UserSecrets/build/GenerateUserSecretsAttribute.targets
@@ -16,11 +16,7 @@ Generates an assembly attribute that has the user secrets id that .AddUserSecret
   <Target Name="GenerateUserSecretsAttribute"
           BeforeTargets="CoreCompile"
           DependsOnTargets="PrepareForBuild;CoreGenerateUserSecretsAttribute"
-          Condition="'$(GenerateUserSecretsAttribute)'=='true' and '$(DesignTimeBuild)'!='true'" >
-    <Warning Text="The assembly attribute 'UserSecretsIdAttribute' could not be generated because the 'UserSecretsId' property was empty or missing. UserSecretsIdAttribute may be required for .AddUserSecrets() to function correctly."
-             Code="USERSECRETS001"
-             Condition="'$(UserSecretsId)'==''" />
-  </Target>
+          Condition="'$(GenerateUserSecretsAttribute)'=='true' and '$(DesignTimeBuild)'!='true'" />
 
   <Target Name="CoreGenerateUserSecretsAttribute"
           Condition="'$(UserSecretsId)'!=''"


### PR DESCRIPTION
PM's don't like the UserSecrets build warning when using Microsoft.AspNetCore.All. So removing it<!-- begrudgingly -->.

Closes https://github.com/aspnet/Configuration/issues/651

Incidentally closes https://github.com/aspnet/Configuration/issues/548 and closes https://github.com/aspnet/Configuration/issues/547 which were about making improvements to the build warning.