### PR TITLE
Use invariant culture in JSON parser

### DIFF
--- a/src/Microsoft.Extensions.Configuration.Json/JsonConfigurationFileParser.cs
+++ b/src/Microsoft.Extensions.Configuration.Json/JsonConfigurationFileParser.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using Newtonsoft.Json;
@@ -65,7 +66,7 @@ namespace Microsoft.Extensions.Configuration.Json
                 case JTokenType.Bytes:
                 case JTokenType.Raw:
                 case JTokenType.Null:
-                    VisitPrimitive(token);
+                    VisitPrimitive(token.Value<JValue>());
                     break;
 
                 default:
@@ -87,7 +88,7 @@ namespace Microsoft.Extensions.Configuration.Json
             }
         }
 
-        private void VisitPrimitive(JToken data)
+        private void VisitPrimitive(JValue data)
         {
             var key = _currentPath;
 
@@ -95,7 +96,7 @@ namespace Microsoft.Extensions.Configuration.Json
             {
                 throw new FormatException(Resources.FormatError_KeyIsDuplicated(key));
             }
-            _data[key] = data.ToString();
+            _data[key] = data.ToString(CultureInfo.InvariantCulture);
         }
 
         private void EnterContext(string context)

--- a/test/Microsoft.Extensions.Configuration.Json.Test/JsonConfigurationTest.cs
+++ b/test/Microsoft.Extensions.Configuration.Json.Test/JsonConfigurationTest.cs
@@ -2,10 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Globalization;
 using System.IO;
 using Microsoft.Extensions.Configuration.Json;
 using Microsoft.Extensions.Configuration.Test;
-using Newtonsoft.Json;
 using Xunit;
 
 namespace Microsoft.Extensions.Configuration
@@ -48,6 +48,28 @@ namespace Microsoft.Extensions.Configuration
 }";
             var jsonConfigSrc = LoadProvider(json);
             Assert.Equal(string.Empty, jsonConfigSrc.Get("name"));
+        }
+
+        [Fact]
+        public void LoadWithCulture()
+        {
+            var previousCulture = CultureInfo.CurrentCulture;
+
+            try
+            {
+                CultureInfo.CurrentCulture = new CultureInfo("fr-FR");
+
+                var json = @"
+{
+    'number': 3.14
+}";
+                var jsonConfigSrc = LoadProvider(json);
+                Assert.Equal("3.14", jsonConfigSrc.Get("number"));
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = previousCulture;
+            }
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/aspnet/Configuration/issues/470.

This is technically a breaking change: previously, a float value bound to string would set it using the current culture, with this change, it would use the invariant culture. But I'd argue that:

1. Such behavior is incorrect, configuration should never use the current culture.
2. It's worth it to be able to bind a float value to float (when having non-English current culture).

cc: @HaoK, @divega