### PR TITLE
Support hierarchical keys.

### DIFF
--- a/src/Microsoft.Extensions.Configuration.AzureKeyVault/AzureKeyVaultConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.AzureKeyVault/AzureKeyVaultConfigurationProvider.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault
                     }
 
                     var value = await _client.GetSecretAsync(secretItem.Id);
-                    var key = _manager.GetKey(value);
+                    var key = _manager.GetKey(value).Replace("--", ":");
                     data.Add(key, value.Value);
                 }
 


### PR DESCRIPTION
The docs here https://docs.microsoft.com/en-us/aspnet/core/security/key-vault-configuration state that using double hyphen "--" in keyvault secret keys will allow for hierarchical keys to be referenced. This doesn't seem to work. I'm not sure if there's something that's intended to be in AzureKeyVaultConfigurationProvider or in a IKeyVaultSecretManager implementation to handle this but I couldn't find anything.