### PR TITLE
Add ConfigurationPath.KeyDelimiter replacement for "--" to GetKey

### DIFF
--- a/samples/KeyVaultSample/EnvironmentSecretManager.cs
+++ b/samples/KeyVaultSample/EnvironmentSecretManager.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Azure.KeyVault.Models;
+using Microsoft.Azure.KeyVault.Models;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.AzureKeyVault;
 
 namespace ConsoleApplication
@@ -19,7 +20,9 @@ namespace ConsoleApplication
 
         public string GetKey(SecretBundle secret)
         {
-            return secret.SecretIdentifier.Name.Substring(_environmentPrefix.Length);
+            return secret.SecretIdentifier.Name
+                                          .Substring(_environmentPrefix.Length)
+                                          .Replace("--", ConfigurationPath.KeyDelimiter);
         }
     }
 }


### PR DESCRIPTION
@pakrym

Without the handling of "--" within a secret identifier name the keys never get turned into sections separated by the ConfigurationPath.KeyDelimiter. Reference the DefaultKeyVaultSecretManager class used by default unless replaced by EnvironmentSecretManager.

I've already opened a PR on the Microsoft docs side to address this problem: 
https://github.com/aspnet/Docs/pull/3525

DefaultKeyVaultSecretManager implementation with "--" handling:
https://github.com/aspnet/Configuration/blob/dev/src/Microsoft.Extensions.Configuration.AzureKeyVault/DefaultKeyVaultSecretManager.cs