### PR TITLE
Update Microsoft.Azure.KeyVault version

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
     <AspNetCoreVersion>2.0.0-*</AspNetCoreVersion>
-    <AzureKeyVaultVersion>2.2.1-preview</AzureKeyVaultVersion>
+    <AzureKeyVaultVersion>2.3.1</AzureKeyVaultVersion>
     <CoreFxVersion>4.4.0-*</CoreFxVersion>
     <IdentityModelActiveDirectoryVersion>3.14.0</IdentityModelActiveDirectoryVersion>
     <InternalAspNetCoreSdkVersion>2.1.0-*</InternalAspNetCoreSdkVersion>

--- a/samples/KeyVaultSample/KeyVaultSample.csproj
+++ b/samples/KeyVaultSample/KeyVaultSample.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\dependencies.props" />
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
     <DebugType>portable</DebugType>
     <OutputType>Exe</OutputType>
   </PropertyGroup>


### PR DESCRIPTION
Address #640 The new stable version 2.3.1 was published today, so we can use this for our RTM release after testing. Will also update BuildTools and Identity.