### PR TITLE
Add additional connection string prefixes for Azure AppServices

### DIFF
--- a/src/Microsoft.Extensions.Configuration.EnvironmentVariables/EnvironmentVariablesConfigurationProvider.cs
+++ b/src/Microsoft.Extensions.Configuration.EnvironmentVariables/EnvironmentVariablesConfigurationProvider.cs
@@ -16,6 +16,13 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables
         private const string MySqlServerPrefix = "MYSQLCONNSTR_";
         private const string SqlAzureServerPrefix = "SQLAZURECONNSTR_";
         private const string SqlServerPrefix = "SQLCONNSTR_";
+        private const string RedisCachePrefix = "REDISCACHECONNSTR_";
+        private const string ApiHubPrefix = "APIHUBCONNSTR_";
+        private const string DocumentDbPrefix = "DOCDBCONNSTR_";
+        private const string EventHubPrefix = "EVENTHUBCONNSTR_";
+        private const string NotificationHubPrefix = "NOTIFICATIONHUBCONNSTR_";
+        private const string PostgreSqkPrefix = "POSTGRESQLCONNSTR_";
+        private const string ServiceBusPrefix = "SERVICEBUSCONNSTR_";
         private const string CustomPrefix = "CUSTOMCONNSTR_";
 
         private const string ConnStrKeyFormat = "ConnectionStrings:{0}";
@@ -87,6 +94,34 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables
             {
                 prefix = SqlServerPrefix;
                 provider = "System.Data.SqlClient";
+            }
+            else if (key.StartsWith(RedisCachePrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                prefix = RedisCachePrefix;
+            }
+            else if (key.StartsWith(ApiHubPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                prefix = ApiHubPrefix;
+            }
+            else if (key.StartsWith(DocumentDbPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                prefix = DocumentDbPrefix;
+            }
+            else if (key.StartsWith(EventHubPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                prefix = EventHubPrefix;
+            }
+            else if (key.StartsWith(NotificationHubPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                prefix = NotificationHubPrefix;
+            }
+            else if (key.StartsWith(PostgreSqkPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                prefix = PostgreSqkPrefix;
+            }
+            else if (key.StartsWith(ServiceBusPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                prefix = ServiceBusPrefix;
             }
             else if (key.StartsWith(CustomPrefix, StringComparison.OrdinalIgnoreCase))
             {

--- a/test/Microsoft.Extensions.Configuration.EnvironmentVariables.Test/EnvironmentVariablesTest.cs
+++ b/test/Microsoft.Extensions.Configuration.EnvironmentVariables.Test/EnvironmentVariablesTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections;
 using Microsoft.Extensions.Configuration.Test;
 using Xunit;
@@ -58,6 +57,13 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables.Test
                     {"SQLCONNSTR_db2", "SQLConnStr"},
                     {"MYSQLCONNSTR_db3", "MySQLConnStr"},
                     {"SQLAZURECONNSTR_db4", "SQLAzureConnStr"},
+                    {"REDISCACHECONNSTR_db6", "RedisCacheConnStr"},
+                    {"APIHUBCONNSTR_db7", "ApiHubConnStr"},
+                    {"DOCDBCONNSTR_db8", "DocDbConnStr"},
+                    {"EVENTHUBCONNSTR_db9", "EventHubConnStr"},
+                    {"NOTIFICATIONHUBCONNSTR_db10", "NotificationHubConnStr"},
+                    {"POSTGRESQLCONNSTR_db11", "PostgreSqlConnStr"},
+                    {"SERVICEBUSCONNSTR_db12", "ServiceBusConnStr"},
                     {"CommonEnv", "CommonEnvValue"},
                 };
             var envConfigSrc = new EnvironmentVariablesConfigurationProvider();
@@ -74,6 +80,13 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables.Test
             Assert.Equal("MySql.Data.MySqlClient", envConfigSrc.Get("ConnectionStrings:db3_ProviderName"));
             Assert.Equal("SQLAzureConnStr", envConfigSrc.Get("ConnectionStrings:db4"));
             Assert.Equal("System.Data.SqlClient", envConfigSrc.Get("ConnectionStrings:db4_ProviderName"));
+            Assert.Equal("RedisCacheConnStr", envConfigSrc.Get("ConnectionStrings:db6"));
+            Assert.Equal("ApiHubConnStr", envConfigSrc.Get("ConnectionStrings:db7"));
+            Assert.Equal("DocDbConnStr", envConfigSrc.Get("ConnectionStrings:db8"));
+            Assert.Equal("EventHubConnStr", envConfigSrc.Get("ConnectionStrings:db9"));
+            Assert.Equal("NotificationHubConnStr", envConfigSrc.Get("ConnectionStrings:db10"));
+            Assert.Equal("PostgreSqlConnStr", envConfigSrc.Get("ConnectionStrings:db11"));
+            Assert.Equal("ServiceBusConnStr", envConfigSrc.Get("ConnectionStrings:db12"));
             Assert.Equal("CommonEnvValue", envConfigSrc.Get("CommonEnv"));
         }
 
@@ -86,6 +99,13 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables.Test
                 {"SQLCONNSTR_db2", "SQLConnStr"},
                 {"MYSQLCONNSTR_db3", "MySQLConnStr"},
                 {"SQLAZURECONNSTR_db4", "SQLAzureConnStr"},
+                {"REDISCACHECONNSTR_db6", "RedisCacheConnStr"},
+                {"APIHUBCONNSTR_db7", "ApiHubConnStr"},
+                {"DOCDBCONNSTR_db8", "DocDbConnStr"},
+                {"EVENTHUBCONNSTR_db9", "EventHubConnStr"},
+                {"NOTIFICATIONHUBCONNSTR_db10", "NotificationHubConnStr"},
+                {"POSTGRESQLCONNSTR_db11", "PostgreSqlConnStr"},
+                {"SERVICEBUSCONNSTR_db12", "ServiceBusConnStr"},
                 {"CommonEnv", "CommonEnvValue"},
             };
             var envConfigSrc = new EnvironmentVariablesConfigurationProvider("ConnectionStrings:");
@@ -99,6 +119,13 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables.Test
             Assert.Equal("MySql.Data.MySqlClient", envConfigSrc.Get("db3_ProviderName"));
             Assert.Equal("SQLAzureConnStr", envConfigSrc.Get("db4"));
             Assert.Equal("System.Data.SqlClient", envConfigSrc.Get("db4_ProviderName"));
+            Assert.Equal("RedisCacheConnStr", envConfigSrc.Get("ConnectionStrings:db6"));
+            Assert.Equal("ApiHubConnStr", envConfigSrc.Get("ConnectionStrings:db7"));
+            Assert.Equal("DocDbConnStr", envConfigSrc.Get("ConnectionStrings:db8"));
+            Assert.Equal("EventHubConnStr", envConfigSrc.Get("ConnectionStrings:db9"));
+            Assert.Equal("NotificationHubConnStr", envConfigSrc.Get("ConnectionStrings:db10"));
+            Assert.Equal("PostgreSqlConnStr", envConfigSrc.Get("ConnectionStrings:db11"));
+            Assert.Equal("ServiceBusConnStr", envConfigSrc.Get("ConnectionStrings:db12"));
         }
 
         [Fact]

--- a/test/Microsoft.Extensions.Configuration.EnvironmentVariables.Test/EnvironmentVariablesTest.cs
+++ b/test/Microsoft.Extensions.Configuration.EnvironmentVariables.Test/EnvironmentVariablesTest.cs
@@ -119,13 +119,13 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables.Test
             Assert.Equal("MySql.Data.MySqlClient", envConfigSrc.Get("db3_ProviderName"));
             Assert.Equal("SQLAzureConnStr", envConfigSrc.Get("db4"));
             Assert.Equal("System.Data.SqlClient", envConfigSrc.Get("db4_ProviderName"));
-            Assert.Equal("RedisCacheConnStr", envConfigSrc.Get("ConnectionStrings:db6"));
-            Assert.Equal("ApiHubConnStr", envConfigSrc.Get("ConnectionStrings:db7"));
-            Assert.Equal("DocDbConnStr", envConfigSrc.Get("ConnectionStrings:db8"));
-            Assert.Equal("EventHubConnStr", envConfigSrc.Get("ConnectionStrings:db9"));
-            Assert.Equal("NotificationHubConnStr", envConfigSrc.Get("ConnectionStrings:db10"));
-            Assert.Equal("PostgreSqlConnStr", envConfigSrc.Get("ConnectionStrings:db11"));
-            Assert.Equal("ServiceBusConnStr", envConfigSrc.Get("ConnectionStrings:db12"));
+            Assert.Equal("RedisCacheConnStr", envConfigSrc.Get("db6"));
+            Assert.Equal("ApiHubConnStr", envConfigSrc.Get("db7"));
+            Assert.Equal("DocDbConnStr", envConfigSrc.Get("db8"));
+            Assert.Equal("EventHubConnStr", envConfigSrc.Get("db9"));
+            Assert.Equal("NotificationHubConnStr", envConfigSrc.Get("db10"));
+            Assert.Equal("PostgreSqlConnStr", envConfigSrc.Get("db11"));
+            Assert.Equal("ServiceBusConnStr", envConfigSrc.Get("db12"));
         }
 
         [Fact]


### PR DESCRIPTION
Azure AppServices has a dropdown list for different connection string types. This PR adds support for the 7 missing connection string types:
* REDISCACHECONNSTR_
* APIHUBCONNSTR_
* DOCDBCONNSTR_
* EVENTHUBCONNSTR_
* NOTIFICATIONHUBCONNSTR_
* POSTGRESQLCONNSTR_
* SERVICEBUSCONNSTR_