### PR TITLE
Trim unintended Environment.NewLine from docker secret contents before adding to Configuration

### DIFF
--- a/src/Config.KeyPerFile/KeyPerFileConfigurationProvider.cs
+++ b/src/Config.KeyPerFile/KeyPerFileConfigurationProvider.cs
@@ -21,6 +21,11 @@ namespace Microsoft.Extensions.Configuration.KeyPerFile
         private static string NormalizeKey(string key)
             => key.Replace("__", ConfigurationPath.KeyDelimiter);
 
+        private static string TrimNewLine(string value)
+            => value.EndsWith(Environment.NewLine)
+                ? value.Substring(0, value.Length - Environment.NewLine.Length)
+                : value;
+
         /// <summary>
         /// Loads the docker secrets.
         /// </summary>
@@ -58,7 +63,7 @@ namespace Microsoft.Extensions.Configuration.KeyPerFile
                 {
                     if (Source.IgnoreCondition == null || !Source.IgnoreCondition(file.Name))
                     {
-                        Data.Add(NormalizeKey(file.Name), streamReader.ReadToEnd());
+                        Data.Add(NormalizeKey(file.Name), TrimNewLine(streamReader.ReadToEnd()));
                     }
                 }
             }


### PR DESCRIPTION
Docker secrets created on a Linux swarm using `echo "secret contents" | docker secret create test-secret -` will append a newline on the end of the secret contents. In a dotnetcore app running in a dockerized service with this secret exposed to the service, the `DockerSecretsConfigurationProvider` reads the secret with the newline character into the Configuration (resulting in something like "secret contents\n"). This is clearly not the intended secret contents.

Addresses Issue #701