### PR TITLE
Make AzureKeyVault configuration classes public. Use IKeyVaultClient interfaces.

### DIFF
--- a/src/Config.AzureKeyVault/AzureKeyVaultConfigurationExtensions.cs
+++ b/src/Config.AzureKeyVault/AzureKeyVaultConfigurationExtensions.cs
@@ -7,22 +7,23 @@ using System.Threading.Tasks;
 using Microsoft.Azure.KeyVault;
 using Microsoft.Extensions.Configuration.AzureKeyVault;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using IKeyVaultClient = Microsoft.Azure.KeyVault.IKeyVaultClient;
 
 namespace Microsoft.Extensions.Configuration
 {
     /// <summary>
-    /// Extension methods for registering <see cref="AzureKeyVaultConfigurationProvider"/> with <see cref="IConfigurationBuilder"/>.
+    /// Extension methods for registering <see cref="AzureKeyVaultConfigurationProvider" /> with <see cref="IConfigurationBuilder" />.
     /// </summary>
     public static class AzureKeyVaultConfigurationExtensions
     {
         /// <summary>
-        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from the Azure KeyVault.
+        /// Adds an <see cref="IConfigurationProvider" /> that reads configuration values from the Azure KeyVault.
         /// </summary>
-        /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder" /> to add to.</param>
         /// <param name="vault">The Azure KeyVault uri.</param>
         /// <param name="clientId">The application client id.</param>
         /// <param name="clientSecret">The client secret to use for authentication.</param>
-        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        /// <returns>The <see cref="IConfigurationBuilder" />.</returns>
         public static IConfigurationBuilder AddAzureKeyVault(
             this IConfigurationBuilder configurationBuilder,
             string vault,
@@ -33,14 +34,14 @@ namespace Microsoft.Extensions.Configuration
         }
 
         /// <summary>
-        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from the Azure KeyVault.
+        /// Adds an <see cref="IConfigurationProvider" /> that reads configuration values from the Azure KeyVault.
         /// </summary>
-        /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder" /> to add to.</param>
         /// <param name="vault">The Azure KeyVault uri.</param>
         /// <param name="clientId">The application client id.</param>
         /// <param name="clientSecret">The client secret to use for authentication.</param>
-        /// <param name="manager">The <see cref="IKeyVaultSecretManager"/> instance used to control secret loading.</param>
-        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        /// <param name="manager">The <see cref="IKeyVaultSecretManager" /> instance used to control secret loading.</param>
+        /// <returns>The <see cref="IConfigurationBuilder" />.</returns>
         public static IConfigurationBuilder AddAzureKeyVault(
             this IConfigurationBuilder configurationBuilder,
             string vault,
@@ -49,35 +50,27 @@ namespace Microsoft.Extensions.Configuration
             IKeyVaultSecretManager manager)
         {
             if (clientId == null)
-            {
                 throw new ArgumentNullException(nameof(clientId));
-            }
+
             if (clientSecret == null)
-            {
                 throw new ArgumentNullException(nameof(clientSecret));
+
+            Task<string> AuthenticationCallback(string authority, string resource, string scope)
+            {
+                return GetTokenFromClientSecret(authority, resource, clientId, clientSecret);
             }
-            KeyVaultClient.AuthenticationCallback callback =
-                (authority, resource, scope) => GetTokenFromClientSecret(authority, resource, clientId, clientSecret);
 
-            return configurationBuilder.AddAzureKeyVault(vault, new KeyVaultClient(callback), manager);
-        }
-
-        private static async Task<string> GetTokenFromClientSecret(string authority, string resource, string clientId, string clientSecret)
-        {
-            var authContext = new AuthenticationContext(authority);
-            var clientCred = new ClientCredential(clientId, clientSecret);
-            var result = await authContext.AcquireTokenAsync(resource, clientCred);
-            return result.AccessToken;
+            return configurationBuilder.AddAzureKeyVault(vault, new KeyVaultClient(AuthenticationCallback), manager);
         }
 
         /// <summary>
-        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from the Azure KeyVault.
+        /// Adds an <see cref="IConfigurationProvider" /> that reads configuration values from the Azure KeyVault.
         /// </summary>
-        /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder" /> to add to.</param>
         /// <param name="vault">Azure KeyVault uri.</param>
         /// <param name="clientId">The application client id.</param>
-        /// <param name="certificate">The <see cref="X509Certificate2"/> to use for authentication.</param>
-        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        /// <param name="certificate">The <see cref="X509Certificate2" /> to use for authentication.</param>
+        /// <returns>The <see cref="IConfigurationBuilder" />.</returns>
         public static IConfigurationBuilder AddAzureKeyVault(
             this IConfigurationBuilder configurationBuilder,
             string vault,
@@ -88,14 +81,14 @@ namespace Microsoft.Extensions.Configuration
         }
 
         /// <summary>
-        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from the Azure KeyVault.
+        /// Adds an <see cref="IConfigurationProvider" /> that reads configuration values from the Azure KeyVault.
         /// </summary>
-        /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder" /> to add to.</param>
         /// <param name="vault">Azure KeyVault uri.</param>
         /// <param name="clientId">The application client id.</param>
-        /// <param name="certificate">The <see cref="X509Certificate2"/> to use for authentication.</param>
-        /// <param name="manager">The <see cref="IKeyVaultSecretManager"/> instance used to control secret loading.</param>
-        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        /// <param name="certificate">The <see cref="X509Certificate2" /> to use for authentication.</param>
+        /// <param name="manager">The <see cref="IKeyVaultSecretManager" /> instance used to control secret loading.</param>
+        /// <returns>The <see cref="IConfigurationBuilder" />.</returns>
         public static IConfigurationBuilder AddAzureKeyVault(
             this IConfigurationBuilder configurationBuilder,
             string vault,
@@ -104,17 +97,58 @@ namespace Microsoft.Extensions.Configuration
             IKeyVaultSecretManager manager)
         {
             if (clientId == null)
-            {
                 throw new ArgumentNullException(nameof(clientId));
-            }
-            if (certificate == null)
-            {
-                throw new ArgumentNullException(nameof(certificate));
-            }
-            KeyVaultClient.AuthenticationCallback callback =
-                (authority, resource, scope) => GetTokenFromClientCertificate(authority, resource, clientId, certificate);
 
-            return configurationBuilder.AddAzureKeyVault(vault, new KeyVaultClient(callback), manager);
+            if (certificate == null)
+                throw new ArgumentNullException(nameof(certificate));
+
+            Task<string> AuthenticationCallback(string authority, string resource, string scope)
+            {
+                return GetTokenFromClientCertificate(authority, resource, clientId, certificate);
+            }
+
+            return configurationBuilder.AddAzureKeyVault(vault, new KeyVaultClient(AuthenticationCallback), manager);
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IConfigurationProvider" /> that reads configuration values from the Azure KeyVault.
+        /// </summary>
+        /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder" /> to add to.</param>
+        /// <param name="vault">Azure KeyVault uri.</param>
+        /// <param name="client">The <see cref="KeyVaultClient" /> to use for retrieving values.</param>
+        /// <param name="manager">The <see cref="IKeyVaultSecretManager" /> instance used to control secret loading.</param>
+        /// <returns>The <see cref="IConfigurationBuilder" />.</returns>
+        public static IConfigurationBuilder AddAzureKeyVault(
+            this IConfigurationBuilder configurationBuilder,
+            string vault,
+            IKeyVaultClient client,
+            IKeyVaultSecretManager manager)
+        {
+            if (configurationBuilder == null)
+                throw new ArgumentNullException(nameof(configurationBuilder));
+
+            if (client == null)
+                throw new ArgumentNullException(nameof(client));
+
+            if (vault == null)
+                throw new ArgumentNullException(nameof(vault));
+
+            configurationBuilder.Add(new AzureKeyVaultConfigurationSource
+            {
+                Client = new KeyVaultClientWrapper(client),
+                Vault = vault,
+                Manager = manager
+            });
+
+            return configurationBuilder;
+        }
+
+        private static async Task<string> GetTokenFromClientSecret(string authority, string resource, string clientId, string clientSecret)
+        {
+            var authContext = new AuthenticationContext(authority);
+            var clientCred = new ClientCredential(clientId, clientSecret);
+            var result = await authContext.AcquireTokenAsync(resource, clientCred);
+            return result.AccessToken;
         }
 
         private static async Task<string> GetTokenFromClientCertificate(string authority, string resource, string clientId, X509Certificate2 certificate)
@@ -122,43 +156,6 @@ namespace Microsoft.Extensions.Configuration
             var authContext = new AuthenticationContext(authority);
             var result = await authContext.AcquireTokenAsync(resource, new ClientAssertionCertificate(clientId, certificate));
             return result.AccessToken;
-        }
-
-        /// <summary>
-        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from the Azure KeyVault.
-        /// </summary>
-        /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
-        /// <param name="vault">Azure KeyVault uri.</param>
-        /// <param name="client">The <see cref="KeyVaultClient"/> to use for retrieving values.</param>
-        /// <param name="manager">The <see cref="IKeyVaultSecretManager"/> instance used to control secret loading.</param>
-        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
-        public static IConfigurationBuilder AddAzureKeyVault(
-            this IConfigurationBuilder configurationBuilder,
-            string vault,
-            KeyVaultClient client,
-            IKeyVaultSecretManager manager)
-        {
-            if (configurationBuilder == null)
-            {
-                throw new ArgumentNullException(nameof(configurationBuilder));
-            }
-            if (client == null)
-            {
-                throw new ArgumentNullException(nameof(client));
-            }
-            if (vault == null)
-            {
-                throw new ArgumentNullException(nameof(vault));
-            }
-
-            configurationBuilder.Add(new AzureKeyVaultConfigurationSource()
-            {
-                Client = client,
-                Vault = vault,
-                Manager = manager
-            });
-
-            return configurationBuilder;
         }
     }
 }

--- a/src/Config.AzureKeyVault/AzureKeyVaultConfigurationProvider.cs
+++ b/src/Config.AzureKeyVault/AzureKeyVaultConfigurationProvider.cs
@@ -9,35 +9,30 @@ using Microsoft.Azure.KeyVault;
 namespace Microsoft.Extensions.Configuration.AzureKeyVault
 {
     /// <summary>
-    /// An AzureKeyVault based <see cref="ConfigurationProvider"/>.
+    /// An AzureKeyVault based <see cref="ConfigurationProvider" />.
     /// </summary>
-    internal class AzureKeyVaultConfigurationProvider : ConfigurationProvider
+    public class AzureKeyVaultConfigurationProvider : ConfigurationProvider
     {
         private readonly IKeyVaultClient _client;
-        private readonly string _vault;
         private readonly IKeyVaultSecretManager _manager;
+        private readonly string _vault;
 
         /// <summary>
-        /// Creates a new instance of <see cref="AzureKeyVaultConfigurationProvider"/>.
+        /// Creates a new instance of <see cref="AzureKeyVaultConfigurationProvider" />.
         /// </summary>
-        /// <param name="client">The <see cref="KeyVaultClient"/> to use for retrieving values.</param>
+        /// <param name="client">The <see cref="KeyVaultClient" /> to use for retrieving values.</param>
         /// <param name="vault">Azure KeyVault uri.</param>
         /// <param name="manager"></param>
         public AzureKeyVaultConfigurationProvider(IKeyVaultClient client, string vault, IKeyVaultSecretManager manager)
         {
-            if (client == null)
-            {
-                throw new ArgumentNullException(nameof(client));
-            }
-            if (vault == null)
-            {
-                throw new ArgumentNullException(nameof(vault));
-            }
-            _client = client;
-            _vault = vault;
+            _client = client ?? throw new ArgumentNullException(nameof(client));
+            _vault = vault ?? throw new ArgumentNullException(nameof(vault));
             _manager = manager;
         }
 
+        /// <summary>
+        /// Loads (or reloads) the data for this provider.
+        /// </summary>
         public override void Load() => LoadAsync().ConfigureAwait(false).GetAwaiter().GetResult();
 
         private async Task LoadAsync()
@@ -50,19 +45,18 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault
                 foreach (var secretItem in secrets)
                 {
                     if (!_manager.Load(secretItem))
-                    {
                         continue;
-                    }
 
                     var value = await _client.GetSecretAsync(secretItem.Id);
                     var key = _manager.GetKey(value);
                     data.Add(key, value.Value);
                 }
 
-                secrets = secrets.NextPageLink != null ?
-                    await _client.GetSecretsNextAsync(secrets.NextPageLink) :
-                    null;
-            } while (secrets != null);
+                secrets = !string.IsNullOrEmpty(secrets.NextPageLink)
+                    ? await _client.GetSecretsNextAsync(secrets.NextPageLink)
+                    : null;
+            }
+            while (secrets != null);
 
             Data = data;
         }

--- a/src/Config.AzureKeyVault/AzureKeyVaultConfigurationSource.cs
+++ b/src/Config.AzureKeyVault/AzureKeyVaultConfigurationSource.cs
@@ -1,19 +1,17 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Azure.KeyVault;
-
 namespace Microsoft.Extensions.Configuration.AzureKeyVault
 {
     /// <summary>
-    /// Represents Azure KeyVault secrets as an <see cref="IConfigurationSource"/>.
+    /// Represents Azure KeyVault secrets as an <see cref="IConfigurationSource" />.
     /// </summary>
     internal class AzureKeyVaultConfigurationSource : IConfigurationSource
     {
         /// <summary>
-        /// Gets or sets the <see cref="KeyVaultClient"/> to use for retrieving values.
+        /// Gets or sets the <see cref="IKeyVaultClient" /> to use for retrieving values.
         /// </summary>
-        public KeyVaultClient Client { get; set; }
+        public IKeyVaultClient Client { get; set; }
 
         /// <summary>
         /// Gets or sets the vault uri.
@@ -21,14 +19,14 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault
         public string Vault { get; set; }
 
         /// <summary>
-        /// Gets or sets the <see cref="IKeyVaultSecretManager"/> instance used to control secret loading.
+        /// Gets or sets the <see cref="IKeyVaultSecretManager" /> instance used to control secret loading.
         /// </summary>
         public IKeyVaultSecretManager Manager { get; set; }
 
         /// <inheritdoc />
         public IConfigurationProvider Build(IConfigurationBuilder builder)
         {
-            return new AzureKeyVaultConfigurationProvider(new KeyVaultClientWrapper(Client), Vault, Manager);
+            return new AzureKeyVaultConfigurationProvider(Client, Vault, Manager);
         }
     }
 }

--- a/src/Config.AzureKeyVault/DefaultKeyVaultSecretManager.cs
+++ b/src/Config.AzureKeyVault/DefaultKeyVaultSecretManager.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Azure.KeyVault;
 using Microsoft.Azure.KeyVault.Models;
 
 namespace Microsoft.Extensions.Configuration.AzureKeyVault
 {
     /// <summary>
-    /// Default implementation of <see cref="IKeyVaultSecretManager"/> that loads all secrets
+    /// Default implementation of <see cref="IKeyVaultSecretManager" /> that loads all secrets
     /// and replaces '--' with ':" in key names.
     /// </summary>
     public class DefaultKeyVaultSecretManager : IKeyVaultSecretManager

--- a/src/Config.AzureKeyVault/IKeyVaultClient.cs
+++ b/src/Config.AzureKeyVault/IKeyVaultClient.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Microsoft.Azure.KeyVault;
 using Microsoft.Azure.KeyVault.Models;
 using Microsoft.Rest.Azure;
 
@@ -13,7 +12,7 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault
     /// against the Key Vault service.
     /// Thread safety: This class is thread-safe.
     /// </summary>
-    internal interface IKeyVaultClient
+    public interface IKeyVaultClient
     {
         /// <summary>List secrets in the specified vault</summary>
         /// <param name="vault">The URL for the vault containing the secrets.</param>

--- a/src/Config.AzureKeyVault/KeyVaultClientWrapper.cs
+++ b/src/Config.AzureKeyVault/KeyVaultClientWrapper.cs
@@ -9,15 +9,15 @@ using Microsoft.Rest.Azure;
 namespace Microsoft.Extensions.Configuration.AzureKeyVault
 {
     /// <inheritdoc />
-    internal class KeyVaultClientWrapper : IKeyVaultClient
+    public class KeyVaultClientWrapper : IKeyVaultClient
     {
-        private readonly KeyVaultClient _keyVaultClientImplementation;
+        private readonly Azure.KeyVault.IKeyVaultClient _keyVaultClientImplementation;
 
         /// <summary>
-        /// Creates a new instance of <see cref="KeyVaultClientWrapper"/>.
+        /// Creates a new instance of <see cref="KeyVaultClientWrapper" />.
         /// </summary>
-        /// <param name="keyVaultClientImplementation">The <see cref="KeyVaultClient"/> instance to wrap.</param>
-        public KeyVaultClientWrapper(KeyVaultClient keyVaultClientImplementation)
+        /// <param name="keyVaultClientImplementation">The <see cref="IKeyVaultClient" /> instance to wrap.</param>
+        public KeyVaultClientWrapper(Azure.KeyVault.IKeyVaultClient keyVaultClientImplementation)
         {
             _keyVaultClientImplementation = keyVaultClientImplementation;
         }


### PR DESCRIPTION
This update includes changing the AzureKeyVault configuration classes from internal to public. This matches many of the other projects similar configuration project classes for reference.

Changes direct reference of KeyVaultClient to use IKeyVaultClient for more extension support, and to support better mocking of KeyVault internals in cases of testingcustom IKeyVaultSecretManager classes.