### PR TITLE
Prevent Deadlock in AzureKeyVaultProvider Load

### DIFF
--- a/src/Config.AzureKeyVault/AzureKeyVaultConfigurationProvider.cs
+++ b/src/Config.AzureKeyVault/AzureKeyVaultConfigurationProvider.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault
         {
             var data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-            var secrets = await _client.GetSecretsAsync(_vault);
+            var secrets = await _client.GetSecretsAsync(_vault).ConfigureAwait(false);
             do
             {
                 foreach (var secretItem in secrets)
@@ -54,13 +54,13 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault
                         continue;
                     }
 
-                    var value = await _client.GetSecretAsync(secretItem.Id);
+                    var value = await _client.GetSecretAsync(secretItem.Id).ConfigureAwait(false);
                     var key = _manager.GetKey(value);
                     data.Add(key, value.Value);
                 }
 
                 secrets = secrets.NextPageLink != null ?
-                    await _client.GetSecretsNextAsync(secrets.NextPageLink) :
+                    await _client.GetSecretsNextAsync(secrets.NextPageLink).ConfigureAwait(false) :
                     null;
             } while (secrets != null);
 


### PR DESCRIPTION
- Add additional ConfigureAwait(false)

Addresses #737 

I've mentioned how this solves the issue with netframework471, I would love to receive some feedback on this change (even though it's really small).

I've followed the practices highlighted in [Don't Block on Async Code](https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html) and [Async/Await - Best Practices in Asynchronous Programming](https://msdn.microsoft.com/en-us/magazine/jj991977.aspx).

I'd be really happy to incorporate any feedback!