### PR TITLE
Add support for DataMember attribute to override JSON settings key

### DIFF
--- a/src/Config.Binder/ConfigurationBinder.cs
+++ b/src/Config.Binder/ConfigurationBinder.cs
@@ -172,15 +172,12 @@ namespace Microsoft.Extensions.Configuration
                 return;
             }
 
-            object[] propertyAttributes = property.GetCustomAttributes(true).ToArray();
-
-            foreach (var propertyAttribute in propertyAttributes)
+            DataMemberAttribute propertyDataMemberAttribute = property.GetCustomAttribute<DataMemberAttribute>(true);
+            if (propertyDataMemberAttribute != null &&
+                propertyDataMemberAttribute.IsNameSetExplicitly &&
+                !string.IsNullOrEmpty( propertyDataMemberAttribute.Name))
             {
-                if (propertyAttribute is DataMemberAttribute dataMemberAttribute && dataMemberAttribute.IsNameSetExplicitly)
-                {
-                    propertyName = dataMemberAttribute.Name;
-                    break;
-                }
+                propertyName = propertyDataMemberAttribute.Name;
             }
 
             propertyValue = BindInstance(property.PropertyType, propertyValue, config.GetSection(propertyName));

--- a/src/Config.Binder/ConfigurationBinder.cs
+++ b/src/Config.Binder/ConfigurationBinder.cs
@@ -10,6 +10,8 @@ using Microsoft.Extensions.Configuration.Binder;
 
 namespace Microsoft.Extensions.Configuration
 {
+    using System.Runtime.Serialization;
+
     /// <summary>
     /// Static helper class that allows binding strongly typed objects to configuration values.
     /// </summary>
@@ -159,6 +161,7 @@ namespace Microsoft.Extensions.Configuration
                 return;
             }
 
+            var propertyName = property.Name;
             var propertyValue = property.GetValue(instance);
             var hasPublicSetter = property.SetMethod != null && property.SetMethod.IsPublic;
 
@@ -169,7 +172,18 @@ namespace Microsoft.Extensions.Configuration
                 return;
             }
 
-            propertyValue = BindInstance(property.PropertyType, propertyValue, config.GetSection(property.Name));
+            object[] propertyAttributes = property.GetCustomAttributes(true).ToArray();
+
+            foreach (var propertyAttribute in propertyAttributes)
+            {
+                if (propertyAttribute is DataMemberAttribute dataMemberAttribute && dataMemberAttribute.IsNameSetExplicitly)
+                {
+                    propertyName = dataMemberAttribute.Name;
+                    break;
+                }
+            }
+
+            propertyValue = BindInstance(property.PropertyType, propertyValue, config.GetSection(propertyName));
 
             if (propertyValue != null && hasPublicSetter)
             {

--- a/test/Config.Binder.Test/ConfigurationBinderTests.cs
+++ b/test/Config.Binder.Test/ConfigurationBinderTests.cs
@@ -9,6 +9,8 @@ using Xunit;
 
 namespace Microsoft.Extensions.Configuration.Binder.Test
 {
+    using System.Runtime.Serialization;
+
     public class ConfigurationBinderTests
     {
         public class ComplexOptions
@@ -29,6 +31,10 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             public string ProtectedSetter { get; protected set; }
             public string InternalSetter { get; internal set; }
             public static string StaticProperty { get; set; }
+            [DataMember]
+            public string DataMemberAttributeNoName { get; set; }
+            [DataMember(Name="data-member-attribute-with-name")]
+            public string DataMemberAttributeWithName { get; set; }
 
             public string ReadOnly
             {
@@ -402,7 +408,8 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             {
                 {"Integer", "-2"},
                 {"Boolean", "TRUe"},
-                {"Nested:Integer", "11"}
+                {"Nested:Integer", "11"},
+                {"data-member-attribute-with-name", "a string"}
             };
             var configurationBuilder = new ConfigurationBuilder();
             configurationBuilder.AddInMemoryCollection(dic);
@@ -414,6 +421,7 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             Assert.True(instance.Boolean);
             Assert.Equal(-2, instance.Integer);
             Assert.Equal(11, instance.Nested.Integer);
+            Assert.Equal("a string", instance.DataMemberAttributeWithName);
         }
 
         [Fact]

--- a/test/Config.Binder.Test/ConfigurationBinderTests.cs
+++ b/test/Config.Binder.Test/ConfigurationBinderTests.cs
@@ -409,7 +409,8 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
                 {"Integer", "-2"},
                 {"Boolean", "TRUe"},
                 {"Nested:Integer", "11"},
-                {"data-member-attribute-with-name", "a string"}
+                {"data-member-attribute-with-name", "a string"},
+                {"DataMemberAttributeNoName","another string"}
             };
             var configurationBuilder = new ConfigurationBuilder();
             configurationBuilder.AddInMemoryCollection(dic);
@@ -422,6 +423,7 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             Assert.Equal(-2, instance.Integer);
             Assert.Equal(11, instance.Nested.Integer);
             Assert.Equal("a string", instance.DataMemberAttributeWithName);
+            Assert.Equal("another string", instance.DataMemberAttributeNoName);
         }
 
         [Fact]


### PR DESCRIPTION
Addresses #774 

Note that this does have the possibility of being a breaking change if consumers are already using DataMember properties that specify a name that is different from what is in their json files.

Consider:

```C#
[DataContract]
public class MySettings
{
    [DataMember(Name="some-name")]
    public string SomeName {get; set;}
}
```

```JSON
{
    "SomeName":"some value"
}
```

If a consumer had code and JSON data like that, this change would cause their configuration setting to end up null at runtime until they update the text in their config file.