### PR TITLE
Add support of IsRequired and property name mapping in binder options

### DIFF
--- a/src/Config.Binder/BinderOptions.cs
+++ b/src/Config.Binder/BinderOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace Microsoft.Extensions.Configuration
 {
@@ -19,6 +20,6 @@ namespace Microsoft.Extensions.Configuration
         /// <summary>
         /// When a required property isn't found the binder will throw an exception.
         /// </summary>
-        public List<string> RequiredProperties { get; set; } = new List<string>();
+        public ICollection<string> RequiredProperties { get; set; } = new Collection<string>();
     }
 }

--- a/src/Config.Binder/BinderOptions.cs
+++ b/src/Config.Binder/BinderOptions.cs
@@ -21,5 +21,10 @@ namespace Microsoft.Extensions.Configuration
         /// When a required property isn't found the binder will throw an exception.
         /// </summary>
         public ICollection<string> RequiredProperties { get; set; } = new Collection<string>();
+
+        /// <summary>
+        /// When ConfigToPropertyMap is specified for a property, use this one instead of the property name.
+        /// </summary>
+        public IDictionary<string, string> ConfigToPropertyMap { get; set; } = new Dictionary<string, string>();
     }
 }

--- a/src/Config.Binder/BinderOptions.cs
+++ b/src/Config.Binder/BinderOptions.cs
@@ -26,5 +26,11 @@ namespace Microsoft.Extensions.Configuration
         /// When ConfigToPropertyMap is specified for a property, use this one instead of the property name.
         /// </summary>
         public IDictionary<string, string> ConfigToPropertyMap { get; set; } = new Dictionary<string, string>();
+
+        /// <summary>
+        /// When a ignored property is set the binder will not bind it.
+        /// </summary>
+        public ICollection<string> IgnoredProperties { get; set; } = new Collection<string>();
+
     }
 }

--- a/src/Config.Binder/BinderOptions.cs
+++ b/src/Config.Binder/BinderOptions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+
 namespace Microsoft.Extensions.Configuration
 {
     /// <summary>
@@ -13,5 +15,10 @@ namespace Microsoft.Extensions.Configuration
         /// If true, the binder will attempt to set all non read-only properties.
         /// </summary>
         public bool BindNonPublicProperties { get; set; }
+
+        /// <summary>
+        /// When a required property isn't found the binder will throw an exception.
+        /// </summary>
+        public List<string> RequiredProperties { get; set; } = new List<string>();
     }
 }

--- a/src/Config.Binder/ConfigurationBinder.cs
+++ b/src/Config.Binder/ConfigurationBinder.cs
@@ -194,7 +194,7 @@ namespace Microsoft.Extensions.Configuration
                     }
                 }
 
-                foreach (var property in GetAllProperties(instance.GetType().GetTypeInfo()))
+                foreach (var property in GetAllProperties(instance.GetType().GetTypeInfo()).Where(p=>!options.IgnoredProperties.Contains(p.Name)))
                 {
                     BindProperty(property, instance, configuration, options);
                 }

--- a/src/Config.Binder/ConfigurationBinder.cs
+++ b/src/Config.Binder/ConfigurationBinder.cs
@@ -180,6 +180,14 @@ namespace Microsoft.Extensions.Configuration
         {
             if (instance != null)
             {
+                foreach(var requiredProperty in options.RequiredProperties)
+                {
+                    if (configuration.GetSection(requiredProperty)?.Value == null)
+                    {
+                        throw new SerializationException(Resources.FormatError_FailedBindingRequiredProperty(requiredProperty));
+                    }
+                }
+
                 foreach (var property in GetAllProperties(instance.GetType().GetTypeInfo()))
                 {
                     BindProperty(property, instance, configuration, options);
@@ -205,11 +213,6 @@ namespace Microsoft.Extensions.Configuration
                 // Property doesn't have a value and we cannot set it so there is no
                 // point in going further down the graph
                 return;
-            }
-
-            if (config.GetSection(property.Name)?.Value == null && options.RequiredProperties.Contains(property.Name))
-            {
-                throw new SerializationException(Resources.FormatError_FailedBindingRequiredProperty(property.Name));
             }
 
             propertyValue = BindInstance(property.PropertyType, propertyValue, config.GetSection(property.Name), options);

--- a/src/Config.Binder/ConfigurationBinder.cs
+++ b/src/Config.Binder/ConfigurationBinder.cs
@@ -206,7 +206,7 @@ namespace Microsoft.Extensions.Configuration
                 // point in going further down the graph
                 return;
             }
-
+            DataMemberAttribute propertyDataMemberAttribute = property.GetCustomAttribute<DataMemberAttribute>(true);
             propertyValue = BindInstance(property.PropertyType, propertyValue, config.GetSection(property.Name), options);
 
 

--- a/src/Config.Binder/ConfigurationBinder.cs
+++ b/src/Config.Binder/ConfigurationBinder.cs
@@ -182,9 +182,15 @@ namespace Microsoft.Extensions.Configuration
             {
                 foreach (var requiredProperty in options.RequiredProperties)
                 {
-                    if (configuration.GetSection(requiredProperty)?.Value == null)
+                    var propertyName = requiredProperty;
+                    if (options.ConfigToPropertyMap.ContainsKey(propertyName) && !string.IsNullOrEmpty(options.ConfigToPropertyMap[propertyName]))
                     {
-                        throw new InvalidOperationException(Resources.FormatError_FailedBindingRequiredProperty(requiredProperty));
+                        propertyName = options.ConfigToPropertyMap[propertyName];
+                    }
+
+                    if (configuration.GetSection(propertyName)?.Value == null)
+                    {
+                        throw new InvalidOperationException(Resources.FormatError_FailedBindingRequiredProperty(propertyName));
                     }
                 }
 

--- a/src/Config.Binder/ConfigurationBinder.cs
+++ b/src/Config.Binder/ConfigurationBinder.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Extensions.Configuration
         {
             if (instance != null)
             {
-                foreach(var requiredProperty in options.RequiredProperties)
+                foreach (var requiredProperty in options.RequiredProperties)
                 {
                     if (configuration.GetSection(requiredProperty)?.Value == null)
                     {
@@ -204,7 +204,7 @@ namespace Microsoft.Extensions.Configuration
             {
                 return;
             }
-
+            var propertyName = property.Name;
             var propertyValue = property.GetValue(instance);
             var hasSetter = property.SetMethod != null && (property.SetMethod.IsPublic || options.BindNonPublicProperties);
 
@@ -215,14 +215,18 @@ namespace Microsoft.Extensions.Configuration
                 return;
             }
 
-            propertyValue = BindInstance(property.PropertyType, propertyValue, config.GetSection(property.Name), options);
+            if (options.ConfigToPropertyMap.ContainsKey(propertyName) && !string.IsNullOrEmpty(options.ConfigToPropertyMap[propertyName]))
+            {
+                propertyName = options.ConfigToPropertyMap[propertyName];
+            }
 
+            propertyValue = BindInstance(property.PropertyType, propertyValue, config.GetSection(propertyName), options);
 
             if (propertyValue != null && hasSetter)
             {
                 property.SetValue(instance, propertyValue);
             }
-         
+
         }
 
         private static object BindToCollection(TypeInfo typeInfo, IConfiguration config, BinderOptions options)

--- a/src/Config.Binder/ConfigurationBinder.cs
+++ b/src/Config.Binder/ConfigurationBinder.cs
@@ -206,7 +206,12 @@ namespace Microsoft.Extensions.Configuration
                 // point in going further down the graph
                 return;
             }
-            DataMemberAttribute propertyDataMemberAttribute = property.GetCustomAttribute<DataMemberAttribute>(true);
+
+            if (config.GetSection(property.Name)?.Value == null && options.RequiredProperties.Contains(property.Name))
+            {
+                throw new SerializationException(Resources.FormatError_FailedBindingRequiredProperty(property.Name));
+            }
+
             propertyValue = BindInstance(property.PropertyType, propertyValue, config.GetSection(property.Name), options);
 
 
@@ -214,11 +219,7 @@ namespace Microsoft.Extensions.Configuration
             {
                 property.SetValue(instance, propertyValue);
             }
-
-            if (config.GetSection(property.Name)?.Value == null && propertyDataMemberAttribute != null && propertyDataMemberAttribute.IsRequired)
-            {
-                throw new SerializationException(Resources.FormatError_FailedBindingRequiredProperty(property.Name));
-            }
+         
         }
 
         private static object BindToCollection(TypeInfo typeInfo, IConfiguration config, BinderOptions options)

--- a/src/Config.Binder/ConfigurationBinder.cs
+++ b/src/Config.Binder/ConfigurationBinder.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Extensions.Configuration
                 {
                     if (configuration.GetSection(requiredProperty)?.Value == null)
                     {
-                        throw new SerializationException(Resources.FormatError_FailedBindingRequiredProperty(requiredProperty));
+                        throw new InvalidOperationException(Resources.FormatError_FailedBindingRequiredProperty(requiredProperty));
                     }
                 }
 

--- a/src/Config.Binder/Properties/Resources.Designer.cs
+++ b/src/Config.Binder/Properties/Resources.Designer.cs
@@ -80,6 +80,12 @@ namespace Microsoft.Extensions.Configuration.Binder
         internal static string FormatError_UnsupportedMultidimensionalArray(object p0)
             => string.Format(CultureInfo.CurrentCulture, GetString("Error_UnsupportedMultidimensionalArray"), p0);
 
+        /// <summary>
+        /// Required member '{0}' is missing or cannot be serialized.
+        /// </summary>
+        internal static string FormatError_FailedBindingRequiredProperty(object p0)
+            => string.Format(CultureInfo.CurrentCulture, GetString("FormatError_FailedBindingRequiredProperty"), p0);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Config.Binder/Resources.resx
+++ b/src/Config.Binder/Resources.resx
@@ -133,6 +133,6 @@
     <value>Cannot create instance of type '{0}' because multidimensional arrays are not supported.</value>
   </data>
   <data name="FormatError_FailedBindingRequiredProperty" xml:space="preserve">
-    <value>Required member '{0}' is missing or cannot be serialized.</value>
+    <value>Required member '{0}' is missing.</value>
   </data>
 </root>

--- a/src/Config.Binder/Resources.resx
+++ b/src/Config.Binder/Resources.resx
@@ -132,4 +132,7 @@
   <data name="Error_UnsupportedMultidimensionalArray" xml:space="preserve">
     <value>Cannot create instance of type '{0}' because multidimensional arrays are not supported.</value>
   </data>
+  <data name="FormatError_FailedBindingRequiredProperty" xml:space="preserve">
+    <value>Required member '{0}' is missing or cannot be serialized.</value>
+  </data>
 </root>

--- a/test/Config.Binder.Test/ConfigurationBinderTests.cs
+++ b/test/Config.Binder.Test/ConfigurationBinderTests.cs
@@ -167,6 +167,26 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
         }
 
         [Fact]
+        public void RequiredPropertyDefinedBind()
+        {
+            var dic = new Dictionary<string, string>
+            {
+                {"Integer", "5"},
+            };
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(dic);
+            var config = configurationBuilder.Build();
+
+            var options = new ComplexOptions();
+
+            config.Bind(options, o =>
+            {
+                o.RequiredProperties.Add("Integer");
+            });
+            Assert.Equal(5, options.Integer);
+        }
+
+        [Fact]
         public void CanBindIConfigurationSectionWithDerivedOptionsSection()
         {
             var dic = new Dictionary<string, string>

--- a/test/Config.Binder.Test/ConfigurationBinderTests.cs
+++ b/test/Config.Binder.Test/ConfigurationBinderTests.cs
@@ -208,6 +208,26 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
         }
 
         [Fact]
+        public void IgnoredPropertyNotBind()
+        {
+            var dic = new Dictionary<string, string>
+            {
+                {"Integer", "5"},
+            };
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(dic);
+            var config = configurationBuilder.Build();
+
+            var options = new ComplexOptions();
+
+            config.Bind(options, o =>
+            {
+                o.IgnoredProperties.Add("Integer");
+            });
+            Assert.Equal(default, options.Integer);
+        }
+
+        [Fact]
         public void PropertyNameMappedBind()
         {
             var dic = new Dictionary<string, string>

--- a/test/Config.Binder.Test/ConfigurationBinderTests.cs
+++ b/test/Config.Binder.Test/ConfigurationBinderTests.cs
@@ -187,6 +187,47 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
         }
 
         [Fact]
+        public void RequiredPropertyDefinedAndNameMappedBind()
+        {
+            var dic = new Dictionary<string, string>
+            {
+                {"Integer2", "5"},
+            };
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(dic);
+            var config = configurationBuilder.Build();
+
+            var options = new ComplexOptions();
+
+            config.Bind(options, o =>
+            {
+                o.RequiredProperties.Add("Integer");
+                o.ConfigToPropertyMap["Integer"] = "Integer2";
+            });
+            Assert.Equal(5, options.Integer);
+        }
+
+        [Fact]
+        public void PropertyNameMappedBind()
+        {
+            var dic = new Dictionary<string, string>
+            {
+                {"Integer2", "5"},
+            };
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(dic);
+            var config = configurationBuilder.Build();
+
+            var options = new ComplexOptions();
+
+            config.Bind(options, o =>
+            {
+                o.ConfigToPropertyMap["Integer"] = "Integer2";
+            });
+            Assert.Equal(5, options.Integer);
+        }
+
+        [Fact]
         public void CanBindIConfigurationSectionWithDerivedOptionsSection()
         {
             var dic = new Dictionary<string, string>

--- a/test/Config.Binder.Test/ConfigurationBinderTests.cs
+++ b/test/Config.Binder.Test/ConfigurationBinderTests.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
 
             var options = new ComplexOptions();
             
-            var exception = Assert.Throws<SerializationException>(
+            var exception = Assert.Throws<InvalidOperationException>(
                () => config.Bind(options, o =>
                {
                    o.RequiredProperties.Add("Integer");

--- a/test/Config.Binder.Test/ConfigurationBinderTests.cs
+++ b/test/Config.Binder.Test/ConfigurationBinderTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Reflection;
+using System.Runtime.Serialization;
 using Xunit;
 
 namespace Microsoft.Extensions.Configuration.Binder.Test
@@ -142,6 +143,27 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             Assert.Equal(-2, options.Integer);
             Assert.Equal(11, options.Nested.Integer);
             Assert.Equal("Derived:Sup", options.Virtual);
+        }
+
+        [Fact]
+        public void ThrowOnRequiredPropertyNotDefinedBind()
+        {
+            var dic = new Dictionary<string, string>
+            {
+                {"Integer", "5"},
+            };
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(dic);
+            var config = configurationBuilder.Build();
+
+            var options = new ComplexOptions();
+            
+            var exception = Assert.Throws<SerializationException>(
+               () => config.Bind(options, o =>
+               {
+                   o.RequiredProperties.Add("Integer");
+                   o.RequiredProperties.Add("Integer2");
+               }));
         }
 
         [Fact]


### PR DESCRIPTION
Addresses Issue #731 #774
Add Required support on binder options
Add Property name mapping support on binder options

Make #775 obsolete