### PR TITLE
Support repeated elements in XML configuration, this addresses #745 and #815

### DIFF
--- a/src/Config.Xml/XmlConfigurationProvider.cs
+++ b/src/Config.Xml/XmlConfigurationProvider.cs
@@ -186,7 +186,7 @@ namespace Microsoft.Extensions.Configuration.Xml
         {
             string name = null;
 
-            while (reader.MoveToNextAttribute() && name == null)
+            while (reader.MoveToNextAttribute())
             {
                 if (string.Equals(reader.LocalName, NameAttributeKey, StringComparison.OrdinalIgnoreCase))
                 {

--- a/src/Config.Xml/XmlConfigurationProvider.cs
+++ b/src/Config.Xml/XmlConfigurationProvider.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Extensions.Configuration.Xml
         /// <param name="stream">The stream to read.</param>
         public override void Load(Stream stream)
         {
-            var data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var configurationValues = new List<IConfigurationValue>();
 
             var readerSettings = new XmlReaderSettings()
             {
@@ -42,57 +42,67 @@ namespace Microsoft.Extensions.Configuration.Xml
 
             using (var reader = Decryptor.CreateDecryptingXmlReader(stream, readerSettings))
             {
-                var prefixStack = new Stack<string>();
+                // record all elements we encounter to check for repeated elements
+                var allElements = new List<Element>();
 
-                SkipUntilRootElement(reader);
-
-                // We process the root element individually since it doesn't contribute to prefix 
-                ProcessAttributes(reader, prefixStack, data, AddNamePrefix);
-                ProcessAttributes(reader, prefixStack, data, AddAttributePair);
-
+                // keep track of the tree we followed to get where we are (breadcrumb style)
+                var currentPath = new Stack<Element>();
+                
                 var preNodeType = reader.NodeType;
                 while (reader.Read())
                 {
                     switch (reader.NodeType)
                     {
                         case XmlNodeType.Element:
-                            prefixStack.Push(reader.LocalName);
-                            ProcessAttributes(reader, prefixStack, data, AddNamePrefix);
-                            ProcessAttributes(reader, prefixStack, data, AddAttributePair);
+                            var parent = currentPath.Any() ? currentPath.Peek() : null;
+                            var element = new Element(parent, reader.LocalName, reader.GetAttribute(NameAttributeKey), GetLineInfo(reader));
+
+                            // check if this element has appeared before
+                            var siblingKeyToken = allElements
+                              .Where(e => e.Parent != null
+                                          && e.Parent == parent
+                                          && string.Equals(e.ElementName, element.ElementName)
+                                          && string.Equals(e.Name, element.Name))
+                              .OrderByDescending(e => e.Index)
+                              .FirstOrDefault();
+                            if (siblingKeyToken != null)
+                            {
+                                siblingKeyToken.Multiple = element.Multiple = true;
+                                element.Index = siblingKeyToken.Index + 1;
+                            }
+
+                            currentPath.Push(element);
+                            allElements.Add(element);
+
+                            ProcessAttributes(reader, currentPath, configurationValues);
 
                             // If current element is self-closing
                             if (reader.IsEmptyElement)
                             {
-                                prefixStack.Pop();
+                                currentPath.Pop();
                             }
                             break;
 
                         case XmlNodeType.EndElement:
-                            if (prefixStack.Any())
+                            if (currentPath.Any())
                             {
                                 // If this EndElement node comes right after an Element node,
                                 // it means there is no text/CDATA node in current element
                                 if (preNodeType == XmlNodeType.Element)
                                 {
-                                    var key = ConfigurationPath.Combine(prefixStack.Reverse());
-                                    data[key] = string.Empty;
+                                    var configurationValue = new ElementContent(currentPath, string.Empty, GetLineInfo(reader));
+                                    configurationValues.Add(configurationValue);
                                 }
 
-                                prefixStack.Pop();
+                                currentPath.Pop();
                             }
                             break;
 
                         case XmlNodeType.CDATA:
                         case XmlNodeType.Text:
                             {
-                                var key = ConfigurationPath.Combine(prefixStack.Reverse());
-                                if (data.ContainsKey(key))
-                                {
-                                    throw new FormatException(Resources.FormatError_KeyIsDuplicated(key,
-                                        GetLineInfo(reader)));
-                                }
-
-                                data[key] = reader.Value;
+                                var configurationValue = new ElementContent(currentPath, reader.Value, GetLineInfo(reader));
+                                configurationValues.Add(configurationValue);
                                 break;
                             }
                         case XmlNodeType.XmlDeclaration:
@@ -118,6 +128,16 @@ namespace Microsoft.Extensions.Configuration.Xml
                 }
             }
 
+            var data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var configurationValue in configurationValues)
+            {
+                var key = configurationValue.Key;
+                if (data.ContainsKey(key))
+                {
+                    throw new FormatException(Resources.FormatError_KeyIsDuplicated(key, configurationValue.LineInfo));
+                }
+                data[key] = configurationValue.Value;
+            }
             Data = data;
         }
 
@@ -136,12 +156,11 @@ namespace Microsoft.Extensions.Configuration.Xml
         private static string GetLineInfo(XmlReader reader)
         {
             var lineInfo = reader as IXmlLineInfo;
-            return lineInfo == null ?  string.Empty :
+            return lineInfo == null ? string.Empty :
                 Resources.FormatMsg_LineInfo(lineInfo.LineNumber, lineInfo.LinePosition);
         }
 
-        private void ProcessAttributes(XmlReader reader, Stack<string> prefixStack, IDictionary<string, string> data,
-            Action<XmlReader, Stack<string>, IDictionary<string, string>, XmlWriter> act, XmlWriter writer = null)
+        private void ProcessAttributes(XmlReader reader, Stack<Element> elementPath, IList<IConfigurationValue> data)
         {
             for (int i = 0; i < reader.AttributeCount; i++)
             {
@@ -153,7 +172,7 @@ namespace Microsoft.Extensions.Configuration.Xml
                     throw new FormatException(Resources.FormatError_NamespaceIsNotSupported(GetLineInfo(reader)));
                 }
 
-                act(reader, prefixStack, data, writer);
+                data.Add(new ElementAttributeValue(elementPath, reader.LocalName, reader.Value, GetLineInfo(reader)));
             }
 
             // Go back to the element containing the attributes we just processed
@@ -197,5 +216,86 @@ namespace Microsoft.Extensions.Configuration.Xml
             data[key] = reader.Value;
             prefixStack.Pop();
         }
+    }
+
+    class Element
+    {
+        // the name of the XML element
+        public string ElementName { get; }
+
+        // the content of the 'Name' attribute, if present
+        public string Name { get; }
+
+        public string LineInfo { get; }
+
+        public bool Multiple { get; set; }
+        public int Index { get; set; }
+        public Element Parent { get; }
+
+        public Element(Element parent, string elementName, string name, string lineInfo)
+        {
+            Parent = parent;
+            ElementName = elementName ?? throw new ArgumentNullException(nameof(elementName));
+            Name = name;
+            LineInfo = lineInfo;
+        }
+
+        public string GetKey()
+        {
+            var tokens = new List<string>(3);
+            // root element does not contribute to prefix
+            if (Parent != null) tokens.Add(ElementName);
+
+            // name attribute contributes to prefix
+            if (Name != null) tokens.Add(Name);
+
+            // index, if multiple elements exist, contributes to prefix
+            if (Multiple) tokens.Add(Index.ToString());
+
+            // the root element without a name attribute does not contribute to prefix at all
+            if (!tokens.Any()) return null;
+            return string.Join(ConfigurationPath.KeyDelimiter, tokens);
+        }
+    }
+
+    interface IConfigurationValue
+    {
+        string Key { get; }
+        string Value { get; }
+        string LineInfo { get; }
+    }
+
+    class ElementContent : IConfigurationValue
+    {
+        private readonly Element[] _elementPath;
+
+        public ElementContent(Stack<Element> elementPath, string content, string lineInfo)
+        {
+            Value = content ?? throw new ArgumentNullException(nameof(content));
+            LineInfo = lineInfo ?? throw new ArgumentNullException(nameof(lineInfo));
+            _elementPath = elementPath?.Reverse().ToArray() ?? throw new ArgumentNullException(nameof(elementPath));
+        }
+
+        public string Key => ConfigurationPath.Combine(_elementPath.Select(e => e.GetKey()).Where(key => key != null));
+        public string Value { get; }
+        public string LineInfo { get; }
+    }
+
+    class ElementAttributeValue : IConfigurationValue
+    {
+        private readonly Element[] _elementPath;
+        private readonly string _attribute;
+
+        public ElementAttributeValue(Stack<Element> elementPath, string attribute, string value, string lineInfo)
+        {
+            _elementPath = elementPath?.Reverse()?.ToArray() ?? throw new ArgumentNullException(nameof(elementPath));
+            _attribute = attribute ?? throw new ArgumentNullException(nameof(attribute));
+            Value = value ?? throw new ArgumentNullException(nameof(value));
+            LineInfo = lineInfo;
+        }
+
+        public string Key => ConfigurationPath.Combine(_elementPath.Select(e => e.GetKey()).Concat(new[] { _attribute }).Where(key => key != null));
+        public string Value { get; }
+        public string LineInfo { get; }
     }
 }

--- a/test/Config.Xml.Test/XmlConfigurationTest.cs
+++ b/test/Config.Xml.Test/XmlConfigurationTest.cs
@@ -161,6 +161,125 @@ namespace Microsoft.Extensions.Configuration.Xml.Test
         }
 
         [Fact]
+        public void RepeatedElementsContributeToPrefix()
+        {
+            var xml =
+              @"<settings>
+                  <DefaultConnection>
+                      <ConnectionString>TestConnectionString1</ConnectionString>
+                      <Provider>SqlClient1</Provider>
+                  </DefaultConnection>
+                  <DefaultConnection>
+                      <ConnectionString>TestConnectionString2</ConnectionString>
+                      <Provider>SqlClient2</Provider>
+                  </DefaultConnection>
+                </settings>";
+            var xmlConfigSrc = new XmlConfigurationProvider(new XmlConfigurationSource());
+            xmlConfigSrc.Load(TestStreamHelpers.StringToStream(xml));
+
+            Assert.Equal("TestConnectionString1", xmlConfigSrc.Get("DefaultConnection:0:ConnectionString"));
+            Assert.Equal("SqlClient1", xmlConfigSrc.Get("DefaultConnection:0:Provider"));
+            Assert.Equal("TestConnectionString2", xmlConfigSrc.Get("DefaultConnection:1:ConnectionString"));
+            Assert.Equal("SqlClient2", xmlConfigSrc.Get("DefaultConnection:1:Provider"));
+        }
+
+        [Fact]
+        public void RepeatedElementsUnderNameContributeToPrefix()
+        {
+            var xml =
+              @"<settings Name='Data'>
+                  <DefaultConnection>
+                      <ConnectionString>TestConnectionString1</ConnectionString>
+                      <Provider>SqlClient1</Provider>
+                  </DefaultConnection>
+                  <DefaultConnection>
+                      <ConnectionString>TestConnectionString2</ConnectionString>
+                      <Provider>SqlClient2</Provider>
+                  </DefaultConnection>
+                </settings>";
+            var xmlConfigSrc = new XmlConfigurationProvider(new XmlConfigurationSource());
+
+            xmlConfigSrc.Load(TestStreamHelpers.StringToStream(xml));
+
+            Assert.Equal("TestConnectionString1", xmlConfigSrc.Get("Data:DefaultConnection:0:ConnectionString"));
+            Assert.Equal("SqlClient1", xmlConfigSrc.Get("Data:DefaultConnection:0:Provider"));
+            Assert.Equal("TestConnectionString2", xmlConfigSrc.Get("Data:DefaultConnection:1:ConnectionString"));
+            Assert.Equal("SqlClient2", xmlConfigSrc.Get("Data:DefaultConnection:1:Provider"));
+        }
+
+        [Fact]
+        public void RepeatedElementsWithSameNameContributeToPrefix()
+        {
+            var xml =
+              @"<settings>
+                  <DefaultConnection Name='Data'>
+                      <ConnectionString>TestConnectionString1</ConnectionString>
+                      <Provider>SqlClient1</Provider>
+                  </DefaultConnection>
+                  <DefaultConnection Name='Data'>
+                      <ConnectionString>TestConnectionString2</ConnectionString>
+                      <Provider>SqlClient2</Provider>
+                  </DefaultConnection>
+                </settings>";
+            var xmlConfigSrc = new XmlConfigurationProvider(new XmlConfigurationSource());
+
+            xmlConfigSrc.Load(TestStreamHelpers.StringToStream(xml));
+
+            Assert.Equal("TestConnectionString1", xmlConfigSrc.Get("DefaultConnection:Data:0:ConnectionString"));
+            Assert.Equal("SqlClient1", xmlConfigSrc.Get("DefaultConnection:Data:0:Provider"));
+            Assert.Equal("TestConnectionString2", xmlConfigSrc.Get("DefaultConnection:Data:1:ConnectionString"));
+            Assert.Equal("SqlClient2", xmlConfigSrc.Get("DefaultConnection:Data:1:Provider"));
+        }
+
+        [Fact]
+        public void RepeatedElementsWithDifferentNamesContributeToPrefix()
+        {
+            var xml =
+              @"<settings>
+                  <DefaultConnection Name='Data1'>
+                      <ConnectionString>TestConnectionString1</ConnectionString>
+                      <Provider>SqlClient1</Provider>
+                  </DefaultConnection>
+                  <DefaultConnection Name='Data2'>
+                      <ConnectionString>TestConnectionString2</ConnectionString>
+                      <Provider>SqlClient2</Provider>
+                  </DefaultConnection>
+                </settings>";
+            var xmlConfigSrc = new XmlConfigurationProvider(new XmlConfigurationSource());
+
+            xmlConfigSrc.Load(TestStreamHelpers.StringToStream(xml));
+
+            Assert.Equal("TestConnectionString1", xmlConfigSrc.Get("DefaultConnection:Data1:ConnectionString"));
+            Assert.Equal("SqlClient1", xmlConfigSrc.Get("DefaultConnection:Data1:Provider"));
+            Assert.Equal("TestConnectionString2", xmlConfigSrc.Get("DefaultConnection:Data2:ConnectionString"));
+            Assert.Equal("SqlClient2", xmlConfigSrc.Get("DefaultConnection:Data2:Provider"));
+        }
+
+        [Fact]
+        public void NestedRepeatedElementsContributeToPrefix()
+        {
+            var xml =
+              @"<settings>
+                  <DefaultConnection>
+                      <ConnectionString>TestConnectionString1</ConnectionString>
+                      <ConnectionString>TestConnectionString2</ConnectionString>
+                  </DefaultConnection>
+                  <DefaultConnection>
+                      <ConnectionString>TestConnectionString3</ConnectionString>
+                      <ConnectionString>TestConnectionString4</ConnectionString>
+                  </DefaultConnection>
+                </settings>";
+            var xmlConfigSrc = new XmlConfigurationProvider(new XmlConfigurationSource());
+
+            xmlConfigSrc.Load(TestStreamHelpers.StringToStream(xml));
+
+            Assert.Equal("TestConnectionString1", xmlConfigSrc.Get("DefaultConnection:0:ConnectionString:0"));
+            Assert.Equal("TestConnectionString2", xmlConfigSrc.Get("DefaultConnection:0:ConnectionString:1"));
+            Assert.Equal("TestConnectionString3", xmlConfigSrc.Get("DefaultConnection:1:ConnectionString:0"));
+            Assert.Equal("TestConnectionString4", xmlConfigSrc.Get("DefaultConnection:1:ConnectionString:1"));
+        }
+
+        [Fact]
         public void SupportMixingNameAttributesAndCommonAttributes()
         {
             var xml =

--- a/test/Config.Xml.Test/XmlConfigurationTest.cs
+++ b/test/Config.Xml.Test/XmlConfigurationTest.cs
@@ -136,6 +136,32 @@ namespace Microsoft.Extensions.Configuration.Xml.Test
         }
 
         [Fact]
+        public void LowercaseNameAttributeContributesToPrefix()
+        {
+            var xml =
+                @"<settings>
+                    <Data name='DefaultConnection'>
+                        <ConnectionString>TestConnectionString</ConnectionString>
+                        <Provider>SqlClient</Provider>
+                    </Data>
+                    <Data name='Inventory'>
+                        <ConnectionString>AnotherTestConnectionString</ConnectionString>
+                        <Provider>MySql</Provider>
+                    </Data>
+                </settings>";
+            var xmlConfigSrc = new XmlConfigurationProvider(new XmlConfigurationSource());
+
+            xmlConfigSrc.Load(TestStreamHelpers.StringToStream(xml));
+
+            Assert.Equal("DefaultConnection", xmlConfigSrc.Get("Data:DefaultConnection:Name"));
+            Assert.Equal("TestConnectionString", xmlConfigSrc.Get("Data:DefaultConnection:ConnectionString"));
+            Assert.Equal("SqlClient", xmlConfigSrc.Get("Data:DefaultConnection:Provider"));
+            Assert.Equal("Inventory", xmlConfigSrc.Get("Data:Inventory:Name"));
+            Assert.Equal("AnotherTestConnectionString", xmlConfigSrc.Get("Data:Inventory:ConnectionString"));
+            Assert.Equal("MySql", xmlConfigSrc.Get("Data:Inventory:Provider"));
+        }
+
+        [Fact]
         public void NameAttributeInRootElementContributesToPrefix()
         {
             var xml =


### PR DESCRIPTION
- Maintain a stack of elements that are encountered during traversal of the XML file
- Detect sibling elements and automatically append indexes to the generated configuration keys, exactly like how the JSON configuration providers does for JSON arrays
- Add a battery of unit tests to verify no existing features were broken in the process

I know this is a considerable change in the existing code, but all existing tests were not modified and are still green. The "Name" feature is still completely supported and as such, this is not a breaking change.

However, adding a "Name" is no longer required for repeated XML elements, the keys will be automatically populated with indexes instead. This is exactly how the JSON provider handles JSON arrays.

Feedback is most welcome!

Thank you for your consideration.