### PR TITLE
[Design] Prototype Stream based config

### DIFF
--- a/Configuration.sln
+++ b/Configuration.sln
@@ -12,59 +12,59 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{B54371FF-B
 		test\Directory.Build.props = test\Directory.Build.props
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.Json", "src\Config.Json\Config.Json.csproj", "{4C4CD1BC-4411-4AFD-9D04-147053F0E259}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.Json", "src\Config.Json\Config.Json.csproj", "{4C4CD1BC-4411-4AFD-9D04-147053F0E259}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.Xml", "src\Config.Xml\Config.Xml.csproj", "{1BEC97C1-56B9-4B2B-A95A-C0DF72F1E96A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.Xml", "src\Config.Xml\Config.Xml.csproj", "{1BEC97C1-56B9-4B2B-A95A-C0DF72F1E96A}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.Json.Test", "test\Config.Json.Test\Config.Json.Test.csproj", "{AE8F8C20-9ED9-4A16-9565-27DF77683789}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.Json.Test", "test\Config.Json.Test\Config.Json.Test.csproj", "{AE8F8C20-9ED9-4A16-9565-27DF77683789}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.Xml.Test", "test\Config.Xml.Test\Config.Xml.Test.csproj", "{0786C785-944A-4423-96A6-4E7BFDB4A1B0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.Xml.Test", "test\Config.Xml.Test\Config.Xml.Test.csproj", "{0786C785-944A-4423-96A6-4E7BFDB4A1B0}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.Test", "test\Config.Test\Config.Test.csproj", "{8777C77E-CA2A-42C1-90CD-2EA9CBF28937}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.Test", "test\Config.Test\Config.Test.csproj", "{8777C77E-CA2A-42C1-90CD-2EA9CBF28937}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration", "src\Config\Config.csproj", "{62BD48B5-BB0C-4C2C-9C4B-04CF75CDCCF1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config", "src\Config\Config.csproj", "{62BD48B5-BB0C-4C2C-9C4B-04CF75CDCCF1}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.FunctionalTests", "test\Config.FunctionalTests\Config.FunctionalTests.csproj", "{EAC77F15-F12E-496B-9184-1B1DA89BFFE9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.FunctionalTests", "test\Config.FunctionalTests\Config.FunctionalTests.csproj", "{EAC77F15-F12E-496B-9184-1B1DA89BFFE9}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.Abstractions", "src\Config.Abstractions\Config.Abstractions.csproj", "{3F1CB08E-9FBD-4CAE-A78A-4AC43F24FC49}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.Abstractions", "src\Config.Abstractions\Config.Abstractions.csproj", "{3F1CB08E-9FBD-4CAE-A78A-4AC43F24FC49}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.Test.Common", "test\Config.Test.Common\Config.Test.Common.csproj", "{29C120E5-F682-4BFB-826B-040A594802CA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.Test.Common", "test\Config.Test.Common\Config.Test.Common.csproj", "{29C120E5-F682-4BFB-826B-040A594802CA}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.CommandLine", "src\Config.CommandLine\Config.CommandLine.csproj", "{D4B7CF9B-4229-44DC-800F-CC39150CEAB2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.CommandLine", "src\Config.CommandLine\Config.CommandLine.csproj", "{D4B7CF9B-4229-44DC-800F-CC39150CEAB2}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.Ini", "src\Config.Ini\Config.Ini.csproj", "{C555C5D5-BF4A-451E-AB43-EBF4DE885EC7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.Ini", "src\Config.Ini\Config.Ini.csproj", "{C555C5D5-BF4A-451E-AB43-EBF4DE885EC7}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.EnvironmentVariables", "src\Config.EnvironmentVariables\Config.EnvironmentVariables.csproj", "{A6A2C665-E5A4-4FD3-AD0C-E33E6CFFCB88}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.EnvironmentVariables", "src\Config.EnvironmentVariables\Config.EnvironmentVariables.csproj", "{A6A2C665-E5A4-4FD3-AD0C-E33E6CFFCB88}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.CommandLine.Test", "test\Config.CommandLine.Test\Config.CommandLine.Test.csproj", "{CE9C8903-AA8A-40E6-B03D-32A08A4A39AF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.CommandLine.Test", "test\Config.CommandLine.Test\Config.CommandLine.Test.csproj", "{CE9C8903-AA8A-40E6-B03D-32A08A4A39AF}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.Ini.Test", "test\Config.Ini.Test\Config.Ini.Test.csproj", "{80A8F10C-E9A6-4677-919D-FE5DB320FEDF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.Ini.Test", "test\Config.Ini.Test\Config.Ini.Test.csproj", "{80A8F10C-E9A6-4677-919D-FE5DB320FEDF}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.EnvironmentVariables.Test", "test\Config.EnvironmentVariables.Test\Config.EnvironmentVariables.Test.csproj", "{7D0F805B-ADFF-4C47-A90C-24DD74416821}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.EnvironmentVariables.Test", "test\Config.EnvironmentVariables.Test\Config.EnvironmentVariables.Test.csproj", "{7D0F805B-ADFF-4C47-A90C-24DD74416821}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.Binder", "src\Config.Binder\Config.Binder.csproj", "{D506FD2F-59A0-4A26-AA6D-E81998B58B34}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.Binder", "src\Config.Binder\Config.Binder.csproj", "{D506FD2F-59A0-4A26-AA6D-E81998B58B34}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.Binder.Test", "test\Config.Binder.Test\Config.Binder.Test.csproj", "{AE6FFE9B-6378-4D57-AA24-7D257F18B235}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.Binder.Test", "test\Config.Binder.Test\Config.Binder.Test.csproj", "{AE6FFE9B-6378-4D57-AA24-7D257F18B235}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.FileExtensions", "src\Config.FileExtensions\Config.FileExtensions.csproj", "{881E7CBC-492C-47C5-98A6-61DD1C753EE6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.FileExtensions", "src\Config.FileExtensions\Config.FileExtensions.csproj", "{881E7CBC-492C-47C5-98A6-61DD1C753EE6}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.FileExtensions.Test", "test\Config.FileExtensions.Test\Config.FileExtensions.Test.csproj", "{F7932F19-EB68-4C52-9CD1-3B51E48C2337}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.FileExtensions.Test", "test\Config.FileExtensions.Test\Config.FileExtensions.Test.csproj", "{F7932F19-EB68-4C52-9CD1-3B51E48C2337}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.AzureKeyVault", "src\Config.AzureKeyVault\Config.AzureKeyVault.csproj", "{A538F609-E902-40CE-8459-4248F9F63558}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.AzureKeyVault", "src\Config.AzureKeyVault\Config.AzureKeyVault.csproj", "{A538F609-E902-40CE-8459-4248F9F63558}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.AzureKeyVault.Test", "test\Config.AzureKeyVault.Test\Config.AzureKeyVault.Test.csproj", "{DA9C1F35-3F92-4F3A-B3B1-A62CCE626D48}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.AzureKeyVault.Test", "test\Config.AzureKeyVault.Test\Config.AzureKeyVault.Test.csproj", "{DA9C1F35-3F92-4F3A-B3B1-A62CCE626D48}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{AB015580-541D-4E2D-B904-E71F8582CC68}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KeyVaultSample", "samples\KeyVaultSample\KeyVaultSample.csproj", "{7AAC49A7-939A-40B1-A86A-705464B4667D}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.UserSecrets", "src\Config.UserSecrets\Config.UserSecrets.csproj", "{58B6443B-1278-4DF9-B7BB-DDF3BFFCF868}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.UserSecrets", "src\Config.UserSecrets\Config.UserSecrets.csproj", "{58B6443B-1278-4DF9-B7BB-DDF3BFFCF868}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.UserSecrets.Test", "test\Config.UserSecrets.Test\Config.UserSecrets.Test.csproj", "{AC7FAD2A-5763-404D-B0FC-3CCA81A16B0A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.UserSecrets.Test", "test\Config.UserSecrets.Test\Config.UserSecrets.Test.csproj", "{AC7FAD2A-5763-404D-B0FC-3CCA81A16B0A}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.KeyPerFile", "src\Config.KeyPerFile\Config.KeyPerFile.csproj", "{69AB0230-D82E-438B-AFE5-85BFF414F1B8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.KeyPerFile", "src\Config.KeyPerFile\Config.KeyPerFile.csproj", "{69AB0230-D82E-438B-AFE5-85BFF414F1B8}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.KeyPerFile.Test", "test\Config.KeyPerFile.Test\Config.KeyPerFile.Test.csproj", "{82A403ED-F827-4FED-BE38-7F87925A07E1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.KeyPerFile.Test", "test\Config.KeyPerFile.Test\Config.KeyPerFile.Test.csproj", "{82A403ED-F827-4FED-BE38-7F87925A07E1}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B926267F-98A3-41F0-90F5-0B1ADF78CA65}"
 	ProjectSection(SolutionItems) = preProject
@@ -231,5 +231,8 @@ Global
 		{69AB0230-D82E-438B-AFE5-85BFF414F1B8} = {F141E2D0-F9B8-4ADB-A19A-7B6FF4CA19A1}
 		{82A403ED-F827-4FED-BE38-7F87925A07E1} = {B54371FF-B920-46C8-8D55-6B19DBB43EBF}
 		{F786716B-DE4D-4C4D-8D5B-38182329E5B5} = {B926267F-98A3-41F0-90F5-0B1ADF78CA65}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {2D9A6EFF-E4DD-4F97-BE9A-6442B0C125EB}
 	EndGlobalSection
 EndGlobal

--- a/src/Config.Abstractions/IConfigurationStreamLoader.cs
+++ b/src/Config.Abstractions/IConfigurationStreamLoader.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+
+namespace Microsoft.Extensions.Configuration
+{
+    /// <summary>
+    /// Loads configuration key/values from a stream into a provider.
+    /// </summary>
+    public interface IConfigurationStreamLoader
+    {
+        /// <summary>
+        /// Loads configuration key/values from a stream into a provider.
+        /// </summary>
+        /// <param name="provider">The <see cref="IConfigurationProvider"/> to store the data.</param>
+        /// <param name="stream">The <see cref="Stream"/> to load configuration data from.</param>
+        void Load(IConfigurationProvider provider, Stream stream);
+    }
+}

--- a/src/Config.FileExtensions/FileConfigurationProvider.cs
+++ b/src/Config.FileExtensions/FileConfigurationProvider.cs
@@ -21,11 +21,7 @@ namespace Microsoft.Extensions.Configuration
         /// <param name="source">The source settings.</param>
         public FileConfigurationProvider(FileConfigurationSource source)
         {
-            if (source == null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-            Source = source;
+            Source = source ?? throw new ArgumentNullException(nameof(source));
 
             if (Source.ReloadOnChange && Source.FileProvider != null)
             {
@@ -105,9 +101,7 @@ namespace Microsoft.Extensions.Configuration
         /// <exception cref="FileNotFoundException">If Optional is <c>false</c> on the source and a
         /// file does not exist at specified Path.</exception>
         public override void Load()
-        {
-            Load(reload: false);
-        }
+            => Load(reload: false);
 
         /// <summary>
         /// Loads this provider's data from a stream.

--- a/src/Config.Json/JsonConfigurationExtensions.cs
+++ b/src/Config.Json/JsonConfigurationExtensions.cs
@@ -14,6 +14,26 @@ namespace Microsoft.Extensions.Configuration
     public static class JsonConfigurationExtensions
     {
         /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="stream"></param>
+        /// <returns></returns>
+        public static IConfigurationBuilder AddJsonStream(this IConfigurationBuilder builder, Stream stream)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+ 
+            return builder.Add<StreamConfigurationSource>(s =>
+            {
+                s.Loader = new JsonConfigurationStreamLoader();
+                s.Stream = stream;
+            });
+        }
+
+        /// <summary>
         /// Adds the JSON configuration provider at <paramref name="path"/> to <paramref name="builder"/>.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
@@ -21,9 +41,7 @@ namespace Microsoft.Extensions.Configuration
         /// <see cref="IConfigurationBuilder.Properties"/> of <paramref name="builder"/>.</param>
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
         public static IConfigurationBuilder AddJsonFile(this IConfigurationBuilder builder, string path)
-        {
-            return AddJsonFile(builder, provider: null, path: path, optional: false, reloadOnChange: false);
-        }
+            => AddJsonFile(builder, provider: null, path: path, optional: false, reloadOnChange: false);
 
         /// <summary>
         /// Adds the JSON configuration provider at <paramref name="path"/> to <paramref name="builder"/>.
@@ -34,9 +52,7 @@ namespace Microsoft.Extensions.Configuration
         /// <param name="optional">Whether the file is optional.</param>
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
         public static IConfigurationBuilder AddJsonFile(this IConfigurationBuilder builder, string path, bool optional)
-        {
-            return AddJsonFile(builder, provider: null, path: path, optional: optional, reloadOnChange: false);
-        }
+            => AddJsonFile(builder, provider: null, path: path, optional: optional, reloadOnChange: false);
 
         /// <summary>
         /// Adds the JSON configuration provider at <paramref name="path"/> to <paramref name="builder"/>.
@@ -48,9 +64,7 @@ namespace Microsoft.Extensions.Configuration
         /// <param name="reloadOnChange">Whether the configuration should be reloaded if the file changes.</param>
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
         public static IConfigurationBuilder AddJsonFile(this IConfigurationBuilder builder, string path, bool optional, bool reloadOnChange)
-        {
-            return AddJsonFile(builder, provider: null, path: path, optional: optional, reloadOnChange: reloadOnChange);
-        }
+            => AddJsonFile(builder, provider: null, path: path, optional: optional, reloadOnChange: reloadOnChange);
 
         /// <summary>
         /// Adds a JSON configuration source to <paramref name="builder"/>.

--- a/src/Config.Json/JsonConfigurationSource.cs
+++ b/src/Config.Json/JsonConfigurationSource.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-
 namespace Microsoft.Extensions.Configuration.Json
 {
     /// <summary>

--- a/src/Config.Json/JsonConfigurationStreamLoader.cs
+++ b/src/Config.Json/JsonConfigurationStreamLoader.cs
@@ -1,0 +1,126 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Extensions.Configuration.Json
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class JsonConfigurationStreamLoader : IConfigurationStreamLoader
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="provider"></param>
+        /// <param name="stream"></param>
+        public void Load(IConfigurationProvider provider, Stream stream)
+            => new JsonLoader(provider, stream).Load();
+
+        // Tweaked from JsonConfigurationFileParser
+        private class JsonLoader
+        {
+            private readonly IConfigurationProvider _provider;
+            private readonly Stack<string> _context = new Stack<string>();
+            private readonly JsonTextReader _reader;
+            private string _currentPath;
+
+            public JsonLoader(IConfigurationProvider provider, Stream stream)
+            {
+                _reader = new JsonTextReader(new StreamReader(stream));
+                _reader.DateParseHandling = DateParseHandling.None;
+                _provider = provider;
+            }
+
+            public void Load()
+            {
+                var jsonConfig = JObject.Load(_reader);
+                VisitJObject(jsonConfig);
+            }
+
+            private void VisitJObject(JObject jObject)
+            {
+                foreach (var property in jObject.Properties())
+                {
+                    EnterContext(property.Name);
+                    VisitProperty(property);
+                    ExitContext();
+                }
+            }
+
+            private void VisitProperty(JProperty property)
+                => VisitToken(property.Value);
+
+            private void VisitToken(JToken token)
+            {
+                switch (token.Type)
+                {
+                    case JTokenType.Object:
+                        VisitJObject(token.Value<JObject>());
+                        break;
+
+                    case JTokenType.Array:
+                        VisitArray(token.Value<JArray>());
+                        break;
+
+                    case JTokenType.Integer:
+                    case JTokenType.Float:
+                    case JTokenType.String:
+                    case JTokenType.Boolean:
+                    case JTokenType.Bytes:
+                    case JTokenType.Raw:
+                    case JTokenType.Null:
+                        VisitPrimitive(token.Value<JValue>());
+                        break;
+
+                    default:
+                        throw new FormatException(Resources.FormatError_UnsupportedJSONToken(
+                            _reader.TokenType,
+                            _reader.Path,
+                            _reader.LineNumber,
+                            _reader.LinePosition));
+                }
+            }
+
+            private void VisitArray(JArray array)
+            {
+                for (int index = 0; index < array.Count; index++)
+                {
+                    EnterContext(index.ToString());
+                    VisitToken(array[index]);
+                    ExitContext();
+                }
+            }
+
+            private void VisitPrimitive(JValue data)
+            {
+                var key = _currentPath;
+
+                if (_provider.TryGet(key, out var ignored))
+                {
+                    throw new FormatException(Resources.FormatError_KeyIsDuplicated(key));
+                }
+                _provider.Set(key, data.ToString(CultureInfo.InvariantCulture));
+            }
+
+            private void EnterContext(string context)
+            {
+                _context.Push(context);
+                _currentPath = ConfigurationPath.Combine(_context.Reverse());
+            }
+
+            private void ExitContext()
+            {
+                _context.Pop();
+                _currentPath = ConfigurationPath.Combine(_context.Reverse());
+            }
+        }
+    }
+}

--- a/src/Config/StreamConfigurationProvider.cs
+++ b/src/Config/StreamConfigurationProvider.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+
+namespace Microsoft.Extensions.Configuration
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class StreamConfigurationSource : IConfigurationSource
+    {
+        /// <summary>
+        /// The stream containing the configuration data.
+        /// </summary>
+        public Stream Stream { get; set; }
+
+        /// <summary>
+        /// The <see cref="IConfigurationStreamLoader"/> used to load the configuration data from the Stream.
+        /// </summary>
+        public IConfigurationStreamLoader Loader { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public IConfigurationProvider Build(IConfigurationBuilder builder)
+            => new StreamConfigurationProvider(this);
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public class StreamConfigurationProvider : ConfigurationProvider
+    {
+        /// <summary>
+        /// The source settings for this provider.
+        /// </summary>
+        public StreamConfigurationSource Source { get; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="source"></param>
+        public StreamConfigurationProvider(StreamConfigurationSource source)
+        {
+            Source = source ?? throw new ArgumentNullException(nameof(source));
+            if (Source.Loader == null)
+            {
+                throw new ArgumentNullException(nameof(Source.Loader));
+            }
+            // Review: should we allow null streams? Seems reasonable to defer default behavior to loader.
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public override void Load()
+            => Source.Loader.Load(this, Source.Stream);
+    }
+}

--- a/test/Config.Json.Test/JsonConfigurationTest.cs
+++ b/test/Config.Json.Test/JsonConfigurationTest.cs
@@ -40,6 +40,26 @@ namespace Microsoft.Extensions.Configuration
         }
 
         [Fact]
+        public void CanLoadValidJsonFromStreamProvider()
+        {
+            var json = @"
+{
+    'firstname': 'test',
+    'test.last.name': 'last.name',
+        'residential.address': {
+            'street.name': 'Something street',
+            'zipcode': '12345'
+        }
+}";
+
+            var config = new ConfigurationBuilder().AddJsonStream(TestStreamHelpers.StringToStream(json)).Build();
+            Assert.Equal("test", config["firstname"]);
+            Assert.Equal("last.name", config["test.last.name"]);
+            Assert.Equal("Something street", config["residential.address:STREET.name"]);
+            Assert.Equal("12345", config["residential.address:zipcode"]);
+        }
+
+        [Fact]
         public void LoadMethodCanHandleEmptyValue()
         {
             var json = @"


### PR DESCRIPTION
Addresses: https://github.com/aspnet/Configuration/issues/662

Took a rough initial cut at what a generic stream source would look like.  There's going to be complications if we want to make it easy to do the file notification/reloads for the stream apis, but I'm thinking (maybe wishfully) that since the old File apis are still there, maybe we can just not support those with the stream apis

New final public API would allow something like:

```C#
            new ConfigurationBuilder()
                  .AddJsonStream(File.OpenRead("some.json") // equiv to  .AddJsonFile("some.json")
                  .AddXmlStream(GetSomeXmlStream())
                  .AddIniStream(GetSomeIniStream())
                  // They can plug in their own loaders and build on them
                  .Add<StreamConfigurationSource>(s => {
                       s.Loader = new EncryptedJsonLoader();
                       s.Stream = File.OpenRead("encrypted.json");
                  }
```

Where its up to the callee to produce the data stream.  

Thoughts? @ajcvickers @davidfowl @shirhatti 

