### PR TITLE
MemoryConfigurationProvider.cs to handle duplicate keys (should use last one added)

### DIFF
--- a/src/Config/MemoryConfigurationProvider.cs
+++ b/src/Config/MemoryConfigurationProvider.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Extensions.Configuration.Memory
             {
                 foreach (var pair in _source.InitialData)
                 {
-                    Data.Add(pair.Key, pair.Value);
+                    Set(pair.Key, pair.Value);
                 }
             }
         }
@@ -43,7 +43,7 @@ namespace Microsoft.Extensions.Configuration.Memory
         /// <param name="value">The configuration value.</param>
         public void Add(string key, string value)
         {
-            Data.Add(key, value);
+            Set(key, value);
         }
 
         /// <summary>


### PR DESCRIPTION
Summary of changes
  - replace instances of Data.Add(key, value) with call to underlying Set(key, value)

Addresses bug where adding key - value pairs when key was already in underlying Data dictionary was throwing an exception.
