### PR TITLE
Initial Support for System.Net.IPAddress.

### DIFF
--- a/src/Config/ConfigurationBuilder.cs
+++ b/src/Config/ConfigurationBuilder.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Net;
 
 namespace Microsoft.Extensions.Configuration
 {
@@ -21,6 +23,13 @@ namespace Microsoft.Extensions.Configuration
         /// and the registered <see cref="IConfigurationProvider"/>s.
         /// </summary>
         public IDictionary<string, object> Properties { get; } = new Dictionary<string, object>();
+
+        static ConfigurationBuilder()
+        {
+            TypeDescriptor.AddAttributes(
+                typeof(IPAddress),
+                new TypeConverterAttribute(typeof(IpAddressConverter)));
+        }
 
         /// <summary>
         /// Adds a new configuration source.

--- a/src/Config/IpAddressConverter.cs
+++ b/src/Config/IpAddressConverter.cs
@@ -1,0 +1,26 @@
+using System;
+using System.ComponentModel;
+using System.Globalization;
+using System.Net;
+
+namespace Microsoft.Extensions.Configuration
+{
+    /// <inheritdoc cref="TypeConverter"/>
+    public sealed class IpAddressConverter : TypeConverter
+    {
+        /// <inheritdoc cref="TypeConverter.CanConvertFrom(ITypeDescriptorContext, Type)"/>
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            if (sourceType == typeof(string)) return true;
+            return base.CanConvertFrom(context, sourceType);
+        }
+
+        /// <inheritdoc cref="TypeConverter.ConvertFrom(ITypeDescriptorContext, CultureInfo, object)"/>
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            var ipString = value as string;
+            if (ipString != null) return IPAddress.Parse(ipString);
+            return base.ConvertFrom(context, culture, value);
+        }
+    }
+}

--- a/test/Config.Binder.Test/ConfigurationBinderTests.cs
+++ b/test/Config.Binder.Test/ConfigurationBinderTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Net;
 using System.Reflection;
 using Xunit;
 
@@ -312,6 +313,8 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
         // enum test
         [InlineData("Constructor", typeof(AttributeTargets))]
         [InlineData("CA761232-ED42-11CE-BACD-00AA0057B223", typeof(Guid))]
+        [InlineData("127.0.0.1", typeof(IPAddress))]
+        [InlineData("16777343", typeof(IPAddress))]
         public void CanReadAllSupportedTypes(string value, Type type)
         {
             // arrange
@@ -325,7 +328,8 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
 
             var optionsType = typeof(GenericOptions<>).MakeGenericType(type);
             var options = Activator.CreateInstance(optionsType);
-            var expectedValue = TypeDescriptor.GetConverter(type).ConvertFromInvariantString(value);
+            var converter = TypeDescriptor.GetConverter(type);
+            var expectedValue = converter?.ConvertFromInvariantString(value);
 
             // act
             config.Bind(options);


### PR DESCRIPTION
My end goal is to be able to serialize all of [ForwardedHeadersOptions](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.builder.forwardedheadersoptions?view=aspnetcore-2.1) to Configuration..

[This is what its used for](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/proxy-load-balancer?view=aspnetcore-2.1).

I assume we don't want to go adding `TypeConverterAttribute`s to existing classes at runtime and risk the side affects it would have on other code. So here are options:

* Actually add `IPAddressConverter` and the other converters I'll need to .NET Core itself (no seriously how does IP Address not have a TypeConverter?)
* Make another attribute and if TypeConverter.CanConvertType() returns false, use that one to load a concerter.
* Somehow decide what I did was basically ok, and just write enough tests and converters for ForwardedHeadersOptions to work.