### PR TITLE
Fix secret assembly attribute generation for F#

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,6 @@
     <SignAssembly>true</SignAssembly>
     <AssemblySigningCertName>Microsoft</AssemblySigningCertName>
     <PackageSigningCertName>MicrosoftNuGet</PackageSigningCertName>
-    <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 </Project>

--- a/src/Config.UserSecrets/build/netstandard2.0/Microsoft.Extensions.Configuration.UserSecrets.targets
+++ b/src/Config.UserSecrets/build/netstandard2.0/Microsoft.Extensions.Configuration.UserSecrets.targets
@@ -2,42 +2,12 @@
 
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-    <GeneratedUserSecretsAttributeFile Condition="'$(GeneratedUserSecretsAttributeFile)'==''">$(IntermediateOutputPath)UserSecretsAssemblyInfo$(DefaultLanguageSourceExtension)</GeneratedUserSecretsAttributeFile>
     <GenerateUserSecretsAttribute Condition="'$(GenerateUserSecretsAttribute)'==''">true</GenerateUserSecretsAttribute>
   </PropertyGroup>
 
-<!--
-********************************************************************************************
-Target: GenerateUserSecretsAttribute
-
-Generates an assembly attribute that has the user secrets id that .AddUserSecrets will find
-********************************************************************************************
--->
-  <Target Name="GenerateUserSecretsAttribute"
-          BeforeTargets="CoreCompile"
-          DependsOnTargets="PrepareForBuild;CoreGenerateUserSecretsAttribute"
-          Condition=" '$(GenerateUserSecretsAttribute)'=='true' " />
-
-  <Target Name="CoreGenerateUserSecretsAttribute"
-          Condition="'$(UserSecretsId)'!=''"
-          Inputs="$(MSBuildAllProjects)"
-          Outputs="$(GeneratedUserSecretsAttributeFile)" >
-    <ItemGroup>
-      <_UserSecretAssemblyAttribute Remove="@(_UserSecretAssemblyAttribute)" />
-      <_UserSecretAssemblyAttribute Include="Microsoft.Extensions.Configuration.UserSecrets.UserSecretsIdAttribute">
-        <_Parameter1>$(UserSecretsId.Trim())</_Parameter1>
-      </_UserSecretAssemblyAttribute>
-    </ItemGroup>
-
-    <ItemGroup>
-      <Compile Remove="$(GeneratedUserSecretsAttributeFile)"       Condition="'$(Language)' != 'F#'" />
-      <CompileBefore Remove="$(GeneratedUserSecretsAttributeFile)" Condition="'$(Language)' == 'F#'" />
-    </ItemGroup>
-
-    <WriteCodeFragment AssemblyAttributes="@(_UserSecretAssemblyAttribute)" Language="$(Language)" OutputFile="$(GeneratedUserSecretsAttributeFile)">
-      <Output Condition="'$(Language)' != 'F#'" TaskParameter="OutputFile" ItemName="Compile" />
-      <Output Condition="'$(Language)' == 'F#'" TaskParameter="OutputFile" ItemName="CompileBefore" />
-      <Output TaskParameter="OutputFile" ItemName="FileWrites" />
-    </WriteCodeFragment>
-  </Target>
+  <ItemGroup Condition=" '$(UserSecretsId)' != '' AND '$(GenerateUserSecretsAttribute)' != 'false' ">
+    <AssemblyAttribute Include="Microsoft.Extensions.Configuration.UserSecrets.UserSecretsIdAttribute">
+      <_Parameter1>$(UserSecretsId.Trim())</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>

--- a/src/Config.UserSecrets/build/netstandard2.0/Microsoft.Extensions.Configuration.UserSecrets.targets
+++ b/src/Config.UserSecrets/build/netstandard2.0/Microsoft.Extensions.Configuration.UserSecrets.targets
@@ -16,7 +16,7 @@ Generates an assembly attribute that has the user secrets id that .AddUserSecret
   <Target Name="GenerateUserSecretsAttribute"
           BeforeTargets="CoreCompile"
           DependsOnTargets="PrepareForBuild;CoreGenerateUserSecretsAttribute"
-          Condition="'$(GenerateUserSecretsAttribute)'=='true' and '$(DesignTimeBuild)'!='true'" />
+          Condition=" '$(GenerateUserSecretsAttribute)'=='true' " />
 
   <Target Name="CoreGenerateUserSecretsAttribute"
           Condition="'$(UserSecretsId)'!=''"
@@ -30,12 +30,13 @@ Generates an assembly attribute that has the user secrets id that .AddUserSecret
     </ItemGroup>
 
     <ItemGroup>
-      <!--Ensure generated file is not already in compile sources-->
-      <Compile Remove="$(GeneratedUserSecretsAttributeFile)"  />
+      <Compile Remove="$(GeneratedUserSecretsAttributeFile)"       Condition="'$(Language)' != 'F#'" />
+      <CompileBefore Remove="$(GeneratedUserSecretsAttributeFile)" Condition="'$(Language)' == 'F#'" />
     </ItemGroup>
 
     <WriteCodeFragment AssemblyAttributes="@(_UserSecretAssemblyAttribute)" Language="$(Language)" OutputFile="$(GeneratedUserSecretsAttributeFile)">
-      <Output TaskParameter="OutputFile" ItemName="Compile" />
+      <Output Condition="'$(Language)' != 'F#'" TaskParameter="OutputFile" ItemName="Compile" />
+      <Output Condition="'$(Language)' == 'F#'" TaskParameter="OutputFile" ItemName="CompileBefore" />
       <Output TaskParameter="OutputFile" ItemName="FileWrites" />
     </WriteCodeFragment>
   </Target>

--- a/test/Config.UserSecrets.Test/Config.UserSecrets.Test.csproj
+++ b/test/Config.UserSecrets.Test/Config.UserSecrets.Test.csproj
@@ -3,11 +3,16 @@
   <PropertyGroup>
     <AssemblyName>Microsoft.Extensions.Configuration.UserSecrets.Test</AssemblyName>
     <RootNamespace>Microsoft.Extensions.Configuration.UserSecrets.Test</RootNamespace>
-    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Config.UserSecrets\Config.UserSecrets.csproj" />
+
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>TargetFramework</_Parameter1>
+      <_Parameter2>$(TargetFramework)</_Parameter2>
+    </AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Config.UserSecrets.Test/MsBuildTargetTest.cs
+++ b/test/Config.UserSecrets.Test/MsBuildTargetTest.cs
@@ -93,7 +93,7 @@ let main argv =
                     break;
             }
 
-            var assemblyInfoFile = Path.Combine(_tempDir, $"obj/Debug/{testTfm}/UserSecretsAssemblyInfo" + sourceExt);
+            var assemblyInfoFile = Path.Combine(_tempDir, $"obj/Debug/{testTfm}/test.AssemblyInfo" + sourceExt);
 
             AssertDotNet("restore");
 

--- a/test/Config.UserSecrets.Test/MsBuildTargetTest.cs
+++ b/test/Config.UserSecrets.Test/MsBuildTargetTest.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
+using System.Reflection;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -38,33 +40,60 @@ namespace Microsoft.Extensions.Configuration.UserSecrets
             }
         }
 
-        [Fact]
-        public void GeneratesAssemblyAttributeFile()
+        [Theory]
+        [InlineData(".csproj", ".cs")]
+        [InlineData(".fsproj", ".fs")]
+        public void GeneratesAssemblyAttributeFile(string projectExt, string sourceExt)
         {
+            var testTfm = typeof(MsBuildTargetTest).Assembly
+                .GetCustomAttributes<AssemblyMetadataAttribute>()
+                .First(f => f.Key == "TargetFramework")
+                .Value;
             var target = Path.Combine(_solutionRoot.FullName, "src", "Config.UserSecrets", "build", "netstandard2.0", "Microsoft.Extensions.Configuration.UserSecrets.targets");
             Directory.CreateDirectory(Path.Combine(_tempDir, "obj"));
             var libName = "Microsoft.Extensions.Configuration.UserSecrets.dll";
             File.Copy(Path.Combine(AppContext.BaseDirectory, libName), Path.Combine(_tempDir, libName));
-            File.Copy(target, Path.Combine(_tempDir, "obj", "test.csproj.usersecretstest.targets")); // imitates how NuGet will import this target
-            var testProj = Path.Combine(_tempDir, "test.csproj");
+            File.Copy(target, Path.Combine(_tempDir, "obj", $"test{projectExt}.usersecretstest.targets")); // imitates how NuGet will import this target
+            var testProj = Path.Combine(_tempDir, "test" + projectExt);
             // should represent a 'dotnet new' project
             File.WriteAllText(testProj, $@"
 <Project Sdk=""Microsoft.NET.Sdk"">
     <PropertyGroup>
+        <Version>1.0.0</Version>
         <OutputType>Exe</OutputType>
         <UserSecretsId>
             xyz123
         </UserSecretsId>
-        <TargetFramework>netcoreapp2.0</TargetFramework>
+        <TargetFramework>{testTfm}</TargetFramework>
+        <SignAssembly>false</SignAssembly>
     </PropertyGroup>
     <ItemGroup>
+        <Compile Include=""Program.fs"" Condition=""'$(Language)' == 'F#'"" />
+        <PackageReference Remove=""Internal.AspNetCore.Sdk"" />
         <Reference Include=""$(MSBuildThisFileDirectory){libName}"" />
     </ItemGroup>
 </Project>
 ");
             _output.WriteLine($"Tempdir = {_tempDir}");
-            File.WriteAllText(Path.Combine(_tempDir, "Program.cs"), "public class Program { public static void Main(){}}");
-            var assemblyInfoFile = Path.Combine(_tempDir, "obj/Debug/netcoreapp2.0/UserSecretsAssemblyInfo.cs");
+
+            switch (projectExt)
+            {
+                case ".csproj":
+                    File.WriteAllText(Path.Combine(_tempDir, "Program.cs"), "public class Program { public static void Main(){}}");
+                    break;
+                case ".fsproj":
+                    File.WriteAllText(Path.Combine(_tempDir, "Program.fs"), @"
+module SomeNamespace.SubNamespace
+open System
+[<EntryPoint>]
+let main argv =
+    printfn ""Hello World from F#!""
+    0
+");
+                    break;
+            }
+
+            var assemblyInfoFile = Path.Combine(_tempDir, $"obj/Debug/{testTfm}/UserSecretsAssemblyInfo" + sourceExt);
 
             AssertDotNet("restore");
 
@@ -74,7 +103,7 @@ namespace Microsoft.Extensions.Configuration.UserSecrets
 
             Assert.True(File.Exists(assemblyInfoFile), $"{assemblyInfoFile} should not exist but does not");
             var contents = File.ReadAllText(assemblyInfoFile);
-            Assert.Contains("[assembly: Microsoft.Extensions.Configuration.UserSecrets.UserSecretsIdAttribute(\"xyz123\")]", contents);
+            Assert.Contains("assembly: Microsoft.Extensions.Configuration.UserSecrets.UserSecretsIdAttribute(\"xyz123\")", contents);
             var lastWrite = new FileInfo(assemblyInfoFile).LastWriteTimeUtc;
 
             AssertDotNet("build --configuration Debug");


### PR DESCRIPTION
Assembly attribute generation for F# requires using a different item group. See Microsoft/visualfsharp#5549 

Also fixes https://github.com/aspnet/Configuration/issues/740

cc @KevinRansom