### PR TITLE
update AppAuthentication to latest version

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -6,7 +6,7 @@
     <InternalAspNetCoreSdkPackageVersion>3.0.0-alpha1-20180919.1</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftAspNetCoreTestingPackageVersion>3.0.0-alpha1-10495</MicrosoftAspNetCoreTestingPackageVersion>
     <MicrosoftAzureKeyVaultPackageVersion>2.3.2</MicrosoftAzureKeyVaultPackageVersion>
-    <MicrosoftAzureServicesAppAuthenticationPackageVersion>1.0.1</MicrosoftAzureServicesAppAuthenticationPackageVersion>
+    <MicrosoftAzureServicesAppAuthenticationPackageVersion>1.0.3</MicrosoftAzureServicesAppAuthenticationPackageVersion>
     <MicrosoftExtensionsFileProvidersPhysicalPackageVersion>3.0.0-alpha1-10495</MicrosoftExtensionsFileProvidersPhysicalPackageVersion>
     <MicrosoftExtensionsPrimitivesPackageVersion>3.0.0-alpha1-10495</MicrosoftExtensionsPrimitivesPackageVersion>
     <MicrosoftNETCoreApp20PackageVersion>2.0.9</MicrosoftNETCoreApp20PackageVersion>


### PR DESCRIPTION
...to pick up this update: https://github.com/Azure/azure-sdk-for-net/pull/4427, which updates the IMDS endpoint used. The old one no longer works.

Workaround is to manually `dotnet add package ...` with latest version but I didn't recognize the issue for a while :)