### PR TITLE
Fix issue where casing of duplicate section keys would cause argument exception

### DIFF
--- a/src/Config/ConfigurationRoot.cs
+++ b/src/Config/ConfigurationRoot.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Extensions.Configuration
             return _providers
                 .Aggregate(Enumerable.Empty<string>(),
                     (seed, source) => source.GetChildKeys(seed, path))
-                .Distinct()
+                .Distinct(StringComparer.OrdinalIgnoreCase)
                 .Select(key => GetSection(path == null ? key : ConfigurationPath.Combine(path, key)));
         }
 

--- a/test/Config.Test/ConfigurationTest.cs
+++ b/test/Config.Test/ConfigurationTest.cs
@@ -301,6 +301,27 @@ namespace Microsoft.Extensions.Configuration.Test
             Assert.Equal("ValueInMem2", config["Key1:Key2"]);
         }
 
+        [Fact]
+        public void NewConfigurationRootMayBeBuiltFromExistingWithDuplicateKeys()
+        {
+            var configurationRoot = new ConfigurationBuilder()
+                                    .AddInMemoryCollection(new Dictionary<string, string>
+                                        {
+                                            {"keya:keyb", "valueA"},
+                                        })
+                                    .AddInMemoryCollection(new Dictionary<string, string>
+                                        {
+                                            {"KEYA:KEYB", "valueB"}
+                                        })
+                                    .Build();
+
+            var newConfigurationRoot = new ConfigurationBuilder()
+                .AddInMemoryCollection(configurationRoot.AsEnumerable())
+                .Build();
+
+            Assert.Equal("valueB", newConfigurationRoot["keya:keyb"]);
+        }
+
         public class TestMemorySourceProvider : MemoryConfigurationProvider, IConfigurationSource
         {
             public TestMemorySourceProvider(Dictionary<string, string> initialData) 


### PR DESCRIPTION
Fixes #778 

Creating a second configurationroot from an existing configurationroot containing duplicate keys differing only in casing would result in an argument exception being thrown.

The fix is to return sections with distinct keys ignoring casing. 



