### PR TITLE
Enable mapping AppSettings to a generic class

### DIFF
--- a/Configuration.sln
+++ b/Configuration.sln
@@ -12,59 +12,59 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{B54371FF-B
 		test\Directory.Build.props = test\Directory.Build.props
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.Json", "src\Config.Json\Config.Json.csproj", "{4C4CD1BC-4411-4AFD-9D04-147053F0E259}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.Json", "src\Config.Json\Config.Json.csproj", "{4C4CD1BC-4411-4AFD-9D04-147053F0E259}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.Xml", "src\Config.Xml\Config.Xml.csproj", "{1BEC97C1-56B9-4B2B-A95A-C0DF72F1E96A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.Xml", "src\Config.Xml\Config.Xml.csproj", "{1BEC97C1-56B9-4B2B-A95A-C0DF72F1E96A}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.Json.Test", "test\Config.Json.Test\Config.Json.Test.csproj", "{AE8F8C20-9ED9-4A16-9565-27DF77683789}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.Json.Test", "test\Config.Json.Test\Config.Json.Test.csproj", "{AE8F8C20-9ED9-4A16-9565-27DF77683789}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.Xml.Test", "test\Config.Xml.Test\Config.Xml.Test.csproj", "{0786C785-944A-4423-96A6-4E7BFDB4A1B0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.Xml.Test", "test\Config.Xml.Test\Config.Xml.Test.csproj", "{0786C785-944A-4423-96A6-4E7BFDB4A1B0}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.Test", "test\Config.Test\Config.Test.csproj", "{8777C77E-CA2A-42C1-90CD-2EA9CBF28937}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.Test", "test\Config.Test\Config.Test.csproj", "{8777C77E-CA2A-42C1-90CD-2EA9CBF28937}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config", "src\Config\Config.csproj", "{62BD48B5-BB0C-4C2C-9C4B-04CF75CDCCF1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration", "src\Config\Config.csproj", "{62BD48B5-BB0C-4C2C-9C4B-04CF75CDCCF1}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.FunctionalTests", "test\Config.FunctionalTests\Config.FunctionalTests.csproj", "{EAC77F15-F12E-496B-9184-1B1DA89BFFE9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.FunctionalTests", "test\Config.FunctionalTests\Config.FunctionalTests.csproj", "{EAC77F15-F12E-496B-9184-1B1DA89BFFE9}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.Abstractions", "src\Config.Abstractions\Config.Abstractions.csproj", "{3F1CB08E-9FBD-4CAE-A78A-4AC43F24FC49}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.Abstractions", "src\Config.Abstractions\Config.Abstractions.csproj", "{3F1CB08E-9FBD-4CAE-A78A-4AC43F24FC49}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.Test.Common", "test\Config.Test.Common\Config.Test.Common.csproj", "{29C120E5-F682-4BFB-826B-040A594802CA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.Test.Common", "test\Config.Test.Common\Config.Test.Common.csproj", "{29C120E5-F682-4BFB-826B-040A594802CA}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.CommandLine", "src\Config.CommandLine\Config.CommandLine.csproj", "{D4B7CF9B-4229-44DC-800F-CC39150CEAB2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.CommandLine", "src\Config.CommandLine\Config.CommandLine.csproj", "{D4B7CF9B-4229-44DC-800F-CC39150CEAB2}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.Ini", "src\Config.Ini\Config.Ini.csproj", "{C555C5D5-BF4A-451E-AB43-EBF4DE885EC7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.Ini", "src\Config.Ini\Config.Ini.csproj", "{C555C5D5-BF4A-451E-AB43-EBF4DE885EC7}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.EnvironmentVariables", "src\Config.EnvironmentVariables\Config.EnvironmentVariables.csproj", "{A6A2C665-E5A4-4FD3-AD0C-E33E6CFFCB88}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.EnvironmentVariables", "src\Config.EnvironmentVariables\Config.EnvironmentVariables.csproj", "{A6A2C665-E5A4-4FD3-AD0C-E33E6CFFCB88}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.CommandLine.Test", "test\Config.CommandLine.Test\Config.CommandLine.Test.csproj", "{CE9C8903-AA8A-40E6-B03D-32A08A4A39AF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.CommandLine.Test", "test\Config.CommandLine.Test\Config.CommandLine.Test.csproj", "{CE9C8903-AA8A-40E6-B03D-32A08A4A39AF}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.Ini.Test", "test\Config.Ini.Test\Config.Ini.Test.csproj", "{80A8F10C-E9A6-4677-919D-FE5DB320FEDF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.Ini.Test", "test\Config.Ini.Test\Config.Ini.Test.csproj", "{80A8F10C-E9A6-4677-919D-FE5DB320FEDF}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.EnvironmentVariables.Test", "test\Config.EnvironmentVariables.Test\Config.EnvironmentVariables.Test.csproj", "{7D0F805B-ADFF-4C47-A90C-24DD74416821}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.EnvironmentVariables.Test", "test\Config.EnvironmentVariables.Test\Config.EnvironmentVariables.Test.csproj", "{7D0F805B-ADFF-4C47-A90C-24DD74416821}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.Binder", "src\Config.Binder\Config.Binder.csproj", "{D506FD2F-59A0-4A26-AA6D-E81998B58B34}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.Binder", "src\Config.Binder\Config.Binder.csproj", "{D506FD2F-59A0-4A26-AA6D-E81998B58B34}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.Binder.Test", "test\Config.Binder.Test\Config.Binder.Test.csproj", "{AE6FFE9B-6378-4D57-AA24-7D257F18B235}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.Binder.Test", "test\Config.Binder.Test\Config.Binder.Test.csproj", "{AE6FFE9B-6378-4D57-AA24-7D257F18B235}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.FileExtensions", "src\Config.FileExtensions\Config.FileExtensions.csproj", "{881E7CBC-492C-47C5-98A6-61DD1C753EE6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.FileExtensions", "src\Config.FileExtensions\Config.FileExtensions.csproj", "{881E7CBC-492C-47C5-98A6-61DD1C753EE6}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.FileExtensions.Test", "test\Config.FileExtensions.Test\Config.FileExtensions.Test.csproj", "{F7932F19-EB68-4C52-9CD1-3B51E48C2337}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.FileExtensions.Test", "test\Config.FileExtensions.Test\Config.FileExtensions.Test.csproj", "{F7932F19-EB68-4C52-9CD1-3B51E48C2337}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.AzureKeyVault", "src\Config.AzureKeyVault\Config.AzureKeyVault.csproj", "{A538F609-E902-40CE-8459-4248F9F63558}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.AzureKeyVault", "src\Config.AzureKeyVault\Config.AzureKeyVault.csproj", "{A538F609-E902-40CE-8459-4248F9F63558}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.AzureKeyVault.Test", "test\Config.AzureKeyVault.Test\Config.AzureKeyVault.Test.csproj", "{DA9C1F35-3F92-4F3A-B3B1-A62CCE626D48}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.AzureKeyVault.Test", "test\Config.AzureKeyVault.Test\Config.AzureKeyVault.Test.csproj", "{DA9C1F35-3F92-4F3A-B3B1-A62CCE626D48}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{AB015580-541D-4E2D-B904-E71F8582CC68}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KeyVaultSample", "samples\KeyVaultSample\KeyVaultSample.csproj", "{7AAC49A7-939A-40B1-A86A-705464B4667D}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.UserSecrets", "src\Config.UserSecrets\Config.UserSecrets.csproj", "{58B6443B-1278-4DF9-B7BB-DDF3BFFCF868}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.UserSecrets", "src\Config.UserSecrets\Config.UserSecrets.csproj", "{58B6443B-1278-4DF9-B7BB-DDF3BFFCF868}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.UserSecrets.Test", "test\Config.UserSecrets.Test\Config.UserSecrets.Test.csproj", "{AC7FAD2A-5763-404D-B0FC-3CCA81A16B0A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.UserSecrets.Test", "test\Config.UserSecrets.Test\Config.UserSecrets.Test.csproj", "{AC7FAD2A-5763-404D-B0FC-3CCA81A16B0A}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.KeyPerFile", "src\Config.KeyPerFile\Config.KeyPerFile.csproj", "{69AB0230-D82E-438B-AFE5-85BFF414F1B8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.KeyPerFile", "src\Config.KeyPerFile\Config.KeyPerFile.csproj", "{69AB0230-D82E-438B-AFE5-85BFF414F1B8}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.KeyPerFile.Test", "test\Config.KeyPerFile.Test\Config.KeyPerFile.Test.csproj", "{82A403ED-F827-4FED-BE38-7F87925A07E1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.KeyPerFile.Test", "test\Config.KeyPerFile.Test\Config.KeyPerFile.Test.csproj", "{82A403ED-F827-4FED-BE38-7F87925A07E1}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B926267F-98A3-41F0-90F5-0B1ADF78CA65}"
 	ProjectSection(SolutionItems) = preProject
@@ -231,8 +231,5 @@ Global
 		{69AB0230-D82E-438B-AFE5-85BFF414F1B8} = {F141E2D0-F9B8-4ADB-A19A-7B6FF4CA19A1}
 		{82A403ED-F827-4FED-BE38-7F87925A07E1} = {B54371FF-B920-46C8-8D55-6B19DBB43EBF}
 		{F786716B-DE4D-4C4D-8D5B-38182329E5B5} = {B926267F-98A3-41F0-90F5-0B1ADF78CA65}
-	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {27FAE6C7-21CD-47A7-9AB5-03A313DDCAE6}
 	EndGlobalSection
 EndGlobal

--- a/Configuration.sln
+++ b/Configuration.sln
@@ -12,59 +12,59 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{B54371FF-B
 		test\Directory.Build.props = test\Directory.Build.props
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.Json", "src\Config.Json\Config.Json.csproj", "{4C4CD1BC-4411-4AFD-9D04-147053F0E259}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.Json", "src\Config.Json\Config.Json.csproj", "{4C4CD1BC-4411-4AFD-9D04-147053F0E259}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.Xml", "src\Config.Xml\Config.Xml.csproj", "{1BEC97C1-56B9-4B2B-A95A-C0DF72F1E96A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.Xml", "src\Config.Xml\Config.Xml.csproj", "{1BEC97C1-56B9-4B2B-A95A-C0DF72F1E96A}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.Json.Test", "test\Config.Json.Test\Config.Json.Test.csproj", "{AE8F8C20-9ED9-4A16-9565-27DF77683789}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.Json.Test", "test\Config.Json.Test\Config.Json.Test.csproj", "{AE8F8C20-9ED9-4A16-9565-27DF77683789}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.Xml.Test", "test\Config.Xml.Test\Config.Xml.Test.csproj", "{0786C785-944A-4423-96A6-4E7BFDB4A1B0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.Xml.Test", "test\Config.Xml.Test\Config.Xml.Test.csproj", "{0786C785-944A-4423-96A6-4E7BFDB4A1B0}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.Test", "test\Config.Test\Config.Test.csproj", "{8777C77E-CA2A-42C1-90CD-2EA9CBF28937}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.Test", "test\Config.Test\Config.Test.csproj", "{8777C77E-CA2A-42C1-90CD-2EA9CBF28937}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration", "src\Config\Config.csproj", "{62BD48B5-BB0C-4C2C-9C4B-04CF75CDCCF1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config", "src\Config\Config.csproj", "{62BD48B5-BB0C-4C2C-9C4B-04CF75CDCCF1}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.FunctionalTests", "test\Config.FunctionalTests\Config.FunctionalTests.csproj", "{EAC77F15-F12E-496B-9184-1B1DA89BFFE9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.FunctionalTests", "test\Config.FunctionalTests\Config.FunctionalTests.csproj", "{EAC77F15-F12E-496B-9184-1B1DA89BFFE9}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.Abstractions", "src\Config.Abstractions\Config.Abstractions.csproj", "{3F1CB08E-9FBD-4CAE-A78A-4AC43F24FC49}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.Abstractions", "src\Config.Abstractions\Config.Abstractions.csproj", "{3F1CB08E-9FBD-4CAE-A78A-4AC43F24FC49}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.Test.Common", "test\Config.Test.Common\Config.Test.Common.csproj", "{29C120E5-F682-4BFB-826B-040A594802CA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.Test.Common", "test\Config.Test.Common\Config.Test.Common.csproj", "{29C120E5-F682-4BFB-826B-040A594802CA}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.CommandLine", "src\Config.CommandLine\Config.CommandLine.csproj", "{D4B7CF9B-4229-44DC-800F-CC39150CEAB2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.CommandLine", "src\Config.CommandLine\Config.CommandLine.csproj", "{D4B7CF9B-4229-44DC-800F-CC39150CEAB2}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.Ini", "src\Config.Ini\Config.Ini.csproj", "{C555C5D5-BF4A-451E-AB43-EBF4DE885EC7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.Ini", "src\Config.Ini\Config.Ini.csproj", "{C555C5D5-BF4A-451E-AB43-EBF4DE885EC7}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.EnvironmentVariables", "src\Config.EnvironmentVariables\Config.EnvironmentVariables.csproj", "{A6A2C665-E5A4-4FD3-AD0C-E33E6CFFCB88}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.EnvironmentVariables", "src\Config.EnvironmentVariables\Config.EnvironmentVariables.csproj", "{A6A2C665-E5A4-4FD3-AD0C-E33E6CFFCB88}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.CommandLine.Test", "test\Config.CommandLine.Test\Config.CommandLine.Test.csproj", "{CE9C8903-AA8A-40E6-B03D-32A08A4A39AF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.CommandLine.Test", "test\Config.CommandLine.Test\Config.CommandLine.Test.csproj", "{CE9C8903-AA8A-40E6-B03D-32A08A4A39AF}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.Ini.Test", "test\Config.Ini.Test\Config.Ini.Test.csproj", "{80A8F10C-E9A6-4677-919D-FE5DB320FEDF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.Ini.Test", "test\Config.Ini.Test\Config.Ini.Test.csproj", "{80A8F10C-E9A6-4677-919D-FE5DB320FEDF}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.EnvironmentVariables.Test", "test\Config.EnvironmentVariables.Test\Config.EnvironmentVariables.Test.csproj", "{7D0F805B-ADFF-4C47-A90C-24DD74416821}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.EnvironmentVariables.Test", "test\Config.EnvironmentVariables.Test\Config.EnvironmentVariables.Test.csproj", "{7D0F805B-ADFF-4C47-A90C-24DD74416821}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.Binder", "src\Config.Binder\Config.Binder.csproj", "{D506FD2F-59A0-4A26-AA6D-E81998B58B34}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.Binder", "src\Config.Binder\Config.Binder.csproj", "{D506FD2F-59A0-4A26-AA6D-E81998B58B34}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.Binder.Test", "test\Config.Binder.Test\Config.Binder.Test.csproj", "{AE6FFE9B-6378-4D57-AA24-7D257F18B235}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.Binder.Test", "test\Config.Binder.Test\Config.Binder.Test.csproj", "{AE6FFE9B-6378-4D57-AA24-7D257F18B235}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.FileExtensions", "src\Config.FileExtensions\Config.FileExtensions.csproj", "{881E7CBC-492C-47C5-98A6-61DD1C753EE6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.FileExtensions", "src\Config.FileExtensions\Config.FileExtensions.csproj", "{881E7CBC-492C-47C5-98A6-61DD1C753EE6}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.FileExtensions.Test", "test\Config.FileExtensions.Test\Config.FileExtensions.Test.csproj", "{F7932F19-EB68-4C52-9CD1-3B51E48C2337}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.FileExtensions.Test", "test\Config.FileExtensions.Test\Config.FileExtensions.Test.csproj", "{F7932F19-EB68-4C52-9CD1-3B51E48C2337}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.AzureKeyVault", "src\Config.AzureKeyVault\Config.AzureKeyVault.csproj", "{A538F609-E902-40CE-8459-4248F9F63558}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.AzureKeyVault", "src\Config.AzureKeyVault\Config.AzureKeyVault.csproj", "{A538F609-E902-40CE-8459-4248F9F63558}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.AzureKeyVault.Test", "test\Config.AzureKeyVault.Test\Config.AzureKeyVault.Test.csproj", "{DA9C1F35-3F92-4F3A-B3B1-A62CCE626D48}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.AzureKeyVault.Test", "test\Config.AzureKeyVault.Test\Config.AzureKeyVault.Test.csproj", "{DA9C1F35-3F92-4F3A-B3B1-A62CCE626D48}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{AB015580-541D-4E2D-B904-E71F8582CC68}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KeyVaultSample", "samples\KeyVaultSample\KeyVaultSample.csproj", "{7AAC49A7-939A-40B1-A86A-705464B4667D}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.UserSecrets", "src\Config.UserSecrets\Config.UserSecrets.csproj", "{58B6443B-1278-4DF9-B7BB-DDF3BFFCF868}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.UserSecrets", "src\Config.UserSecrets\Config.UserSecrets.csproj", "{58B6443B-1278-4DF9-B7BB-DDF3BFFCF868}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.UserSecrets.Test", "test\Config.UserSecrets.Test\Config.UserSecrets.Test.csproj", "{AC7FAD2A-5763-404D-B0FC-3CCA81A16B0A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.UserSecrets.Test", "test\Config.UserSecrets.Test\Config.UserSecrets.Test.csproj", "{AC7FAD2A-5763-404D-B0FC-3CCA81A16B0A}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.KeyPerFile", "src\Config.KeyPerFile\Config.KeyPerFile.csproj", "{69AB0230-D82E-438B-AFE5-85BFF414F1B8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.KeyPerFile", "src\Config.KeyPerFile\Config.KeyPerFile.csproj", "{69AB0230-D82E-438B-AFE5-85BFF414F1B8}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.KeyPerFile.Test", "test\Config.KeyPerFile.Test\Config.KeyPerFile.Test.csproj", "{82A403ED-F827-4FED-BE38-7F87925A07E1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Config.KeyPerFile.Test", "test\Config.KeyPerFile.Test\Config.KeyPerFile.Test.csproj", "{82A403ED-F827-4FED-BE38-7F87925A07E1}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B926267F-98A3-41F0-90F5-0B1ADF78CA65}"
 	ProjectSection(SolutionItems) = preProject
@@ -231,5 +231,8 @@ Global
 		{69AB0230-D82E-438B-AFE5-85BFF414F1B8} = {F141E2D0-F9B8-4ADB-A19A-7B6FF4CA19A1}
 		{82A403ED-F827-4FED-BE38-7F87925A07E1} = {B54371FF-B920-46C8-8D55-6B19DBB43EBF}
 		{F786716B-DE4D-4C4D-8D5B-38182329E5B5} = {B926267F-98A3-41F0-90F5-0B1ADF78CA65}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {27FAE6C7-21CD-47A7-9AB5-03A313DDCAE6}
 	EndGlobalSection
 EndGlobal

--- a/src/Config.Abstractions/IConfiguration.cs
+++ b/src/Config.Abstractions/IConfiguration.cs
@@ -19,6 +19,11 @@ namespace Microsoft.Extensions.Configuration
         string this[string key] { get; set; }
 
         /// <summary>
+        /// The content of the configuration file
+        /// </summary>
+        string FileContent { get; }
+
+        /// <summary>
         /// Gets a configuration sub-section with the specified key.
         /// </summary>
         /// <param name="key">The key of the configuration section.</param>

--- a/src/Config.Abstractions/IConfigurationProvider.cs
+++ b/src/Config.Abstractions/IConfigurationProvider.cs
@@ -12,6 +12,11 @@ namespace Microsoft.Extensions.Configuration
     public interface IConfigurationProvider
     {
         /// <summary>
+        /// The content of the configuration file
+        /// </summary>
+        string FileContent { get; set; }
+
+        /// <summary>
         /// Tries to get a configuration value for the specified key.
         /// </summary>
         /// <param name="key">The key.</param>

--- a/src/Config.Json/JsonConfigurationExtensions.cs
+++ b/src/Config.Json/JsonConfigurationExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using Microsoft.Extensions.Configuration.Json;
 using Microsoft.Extensions.FileProviders;
+using Newtonsoft.Json;
 
 namespace Microsoft.Extensions.Configuration
 {
@@ -91,5 +92,37 @@ namespace Microsoft.Extensions.Configuration
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
         public static IConfigurationBuilder AddJsonFile(this IConfigurationBuilder builder, Action<JsonConfigurationSource> configureSource)
             => builder.Add(configureSource);
+
+        /// <summary>
+        /// Convert the configuration file to a generic type
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="configuration"></param>
+        /// <returns>default when there is no file content</returns>
+        public static T GetConfig<T>(this IConfiguration configuration)
+        {
+            //Validate configuration
+            if (!string.IsNullOrEmpty(configuration.FileContent))
+            {
+                return default(T);
+            }
+
+            //Convert FileContent to generic type
+            return ToGeneric<T>(configuration.FileContent);
+        }
+
+        /// <summary>
+        /// Convert Json to a Generic
+        /// </summary>
+        /// <param name="fileContent"></param>
+        /// <returns></returns>
+        public static T ToGeneric<T>(string fileContent)
+        {
+            return JsonConvert.DeserializeObject<T>(fileContent, new JsonSerializerSettings
+            {
+                //Ignore circular references
+                ReferenceLoopHandling = ReferenceLoopHandling.Ignore
+            });
+        }
     }
 }

--- a/src/Config.Json/JsonConfigurationExtensions.cs
+++ b/src/Config.Json/JsonConfigurationExtensions.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Extensions.Configuration
         public static T GetConfig<T>(this IConfiguration configuration)
         {
             //Validate configuration
-            if (!string.IsNullOrEmpty(configuration.FileContent))
+            if (string.IsNullOrEmpty(configuration.FileContent))
             {
                 return default(T);
             }

--- a/src/Config.Json/JsonConfigurationExtensions.cs
+++ b/src/Config.Json/JsonConfigurationExtensions.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Extensions.Configuration
         public static T GetConfig<T>(this IConfiguration configuration)
         {
             //Validate configuration
-            if (string.IsNullOrEmpty(configuration.FileContent))
+            if (string.IsNullOrEmpty(configuration?.FileContent))
             {
                 return default(T);
             }

--- a/src/Config.Json/JsonConfigurationFileParser.cs
+++ b/src/Config.Json/JsonConfigurationFileParser.cs
@@ -21,20 +21,62 @@ namespace Microsoft.Extensions.Configuration.Json
 
         private JsonTextReader _reader;
 
-        public static IDictionary<string, string> Parse(Stream input)
-            => new JsonConfigurationFileParser().ParseStream(input);
+        public static IDictionary<string, string> Parse(Stream input) => new JsonConfigurationFileParser().ParseStream(input);
+
+        /// <summary>
+        /// Parse a stream to a Json string
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        public static string ParseToString(Stream input)
+        {
+           return new JsonConfigurationFileParser().ParseStreamToString(input);
+        }
 
         private IDictionary<string, string> ParseStream(Stream input)
         {
             _data.Clear();
-            _reader = new JsonTextReader(new StreamReader(input));
-            _reader.DateParseHandling = DateParseHandling.None;
 
-            var jsonConfig = JObject.Load(_reader);
-
+            //Parse a stream to a Json Object
+            var jsonConfig = ParseStreamToJsonObject(input);
+            
             VisitJObject(jsonConfig);
 
             return _data;
+        }
+
+        /// <summary>
+        /// Parse a stream to a Json Object
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        private JObject ParseStreamToJsonObject(Stream input)
+        {
+            //Read stream to json textreader
+            _reader = new JsonTextReader(new StreamReader(input))
+            {
+                DateParseHandling = DateParseHandling.None
+            };
+
+            //load JObject
+            var jsonConfig = JObject.Load(_reader);
+
+            //Return JObject
+            return jsonConfig;
+        }
+
+        /// <summary>
+        /// Parse a stream to a generic object
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        private string ParseStreamToString(Stream input)
+        {
+            //Read stream to json textreader
+            var jsonConfig = ParseStreamToJsonObject(input);
+
+            //Convert to generic
+            return jsonConfig.ToString(Formatting.None);
         }
 
         private void VisitJObject(JObject jObject)

--- a/src/Config.Json/JsonConfigurationFileParser.cs
+++ b/src/Config.Json/JsonConfigurationFileParser.cs
@@ -61,6 +61,9 @@ namespace Microsoft.Extensions.Configuration.Json
             //load JObject
             var jsonConfig = JObject.Load(_reader);
 
+            //Set stream position to the start
+            input.Position = 0;
+
             //Return JObject
             return jsonConfig;
         }

--- a/src/Config.Json/JsonConfigurationProvider.cs
+++ b/src/Config.Json/JsonConfigurationProvider.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Extensions.Configuration.Json
             try
             {
                 Data = JsonConfigurationFileParser.Parse(stream);
+                FileContent = JsonConfigurationFileParser.ParseToString(stream);
             }
             catch (JsonReaderException e)
             {

--- a/src/Config/ChainedConfigurationProvider.cs
+++ b/src/Config/ChainedConfigurationProvider.cs
@@ -16,6 +16,11 @@ namespace Microsoft.Extensions.Configuration
         private readonly IConfiguration _config;
 
         /// <summary>
+        /// The content of the configuration file
+        /// </summary>
+        public string FileContent { get; set; }
+
+        /// <summary>
         /// Initialize a new instance from the source configuration.
         /// </summary>
         /// <param name="source">The source configuration.</param>
@@ -32,6 +37,8 @@ namespace Microsoft.Extensions.Configuration
 
             _config = source.Configuration;
         }
+
+        
 
         /// <summary>
         /// Tries to get a configuration value for the specified key.

--- a/src/Config/ConfigurationProvider.cs
+++ b/src/Config/ConfigurationProvider.cs
@@ -30,6 +30,11 @@ namespace Microsoft.Extensions.Configuration
         protected IDictionary<string, string> Data { get; set; }
 
         /// <summary>
+        /// The content of the configuration file
+        /// </summary>
+        public string FileContent { get; set; }
+
+        /// <summary>
         /// Attempts to find a value with the given key, returns true if one is found, false otherwise.
         /// </summary>
         /// <param name="key">The key to lookup.</param>

--- a/src/Config/ConfigurationRoot.cs
+++ b/src/Config/ConfigurationRoot.cs
@@ -18,6 +18,11 @@ namespace Microsoft.Extensions.Configuration
         private ConfigurationReloadToken _changeToken = new ConfigurationReloadToken();
 
         /// <summary>
+        /// The content of the configuration file
+        /// </summary>
+        public string FileContent { get; set; }
+
+        /// <summary>
         /// Initializes a Configuration root with a list of providers.
         /// </summary>
         /// <param name="providers">The <see cref="IConfigurationProvider"/>s for this configuration.</param>
@@ -34,6 +39,10 @@ namespace Microsoft.Extensions.Configuration
                 p.Load();
                 ChangeToken.OnChange(() => p.GetReloadToken(), () => RaiseChanged());
             }
+
+            //Get File content
+            FileContent = providers.FirstOrDefault(x => !string.IsNullOrEmpty(x.FileContent))?.FileContent;
+
         }
 
         /// <summary>

--- a/src/Config/ConfigurationSection.cs
+++ b/src/Config/ConfigurationSection.cs
@@ -17,6 +17,11 @@ namespace Microsoft.Extensions.Configuration
         private string _key;
 
         /// <summary>
+        /// The content of the configuration file from the Configuration Root
+        /// </summary>
+        public string FileContent => _root.FileContent;
+
+        /// <summary>
         /// Initializes a new instance.
         /// </summary>
         /// <param name="root">The configuration root.</param>
@@ -90,6 +95,8 @@ namespace Microsoft.Extensions.Configuration
                 _root[ConfigurationPath.Combine(Path, key)] = value;
             }
         }
+
+        
 
         /// <summary>
         /// Gets a configuration sub-section with the specified key.

--- a/test/Config.Json.Test/Config.Json.Test.csproj
+++ b/test/Config.Json.Test/Config.Json.Test.csproj
@@ -17,4 +17,10 @@
     <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="Startup\appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/test/Config.Json.Test/JsonConfigurationExtensionsTest.cs
+++ b/test/Config.Json.Test/JsonConfigurationExtensionsTest.cs
@@ -33,5 +33,6 @@ namespace Microsoft.Extensions.Configuration.Json
             var ex = Assert.Throws<FileNotFoundException>(() => new ConfigurationBuilder().AddJsonFile(path).Build());
             Assert.StartsWith($"The configuration file '{path}' was not found and is not optional. The physical path is '", ex.Message);
         }
+        
     }
 }

--- a/test/Config.Json.Test/JsonConfigurationTest.cs
+++ b/test/Config.Json.Test/JsonConfigurationTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Globalization;
 using System.IO;
 using Microsoft.Extensions.Configuration.Json;
+using Microsoft.Extensions.Configuration.Json.Test.Model;
 using Microsoft.Extensions.Configuration.Test;
 using Xunit;
 
@@ -166,6 +167,28 @@ namespace Microsoft.Extensions.Configuration
         public void ThrowFormatExceptionWhenFileIsEmpty()
         {
             var exception = Assert.Throws<FormatException>(() => LoadProvider(@""));
+        }
+
+        [Fact]
+        public void ConvertJsonFileToGenericType()
+        {
+            //Get Startup directory
+            var path = AppDomain.CurrentDomain.BaseDirectory + "Startup";
+
+            //Create builder
+            var builder = new ConfigurationBuilder()
+                .SetBasePath(path)
+                .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true);
+
+            //Build configuration
+            var configuration = builder.Build();
+
+            //Parse appsettings.json to a generic type
+            var appSetting = configuration.GetConfig<AppSettingModel>();
+
+            //Pass test if the object was populated
+            Assert.NotNull(appSetting);
+
         }
     }
 }

--- a/test/Config.Json.Test/Model/AppSettingModel.cs
+++ b/test/Config.Json.Test/Model/AppSettingModel.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Extensions.Configuration.Json.Test.Model
+{
+    public class AppSettingModel
+    {
+        public string RoomDefaultTemperature { get; set; }
+
+        public SpaceshipSettingModel SpaceshipSetting { get; set; }
+    }
+}

--- a/test/Config.Json.Test/Model/SpaceshipSettingModel.cs
+++ b/test/Config.Json.Test/Model/SpaceshipSettingModel.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Extensions.Configuration.Json.Test.Model
+{
+    public class SpaceshipSettingModel
+    {
+        /// <summary>
+        /// Auto Destruct is in milliseconds
+        /// </summary>
+        public string AutoDestructTimeout { get; set; }
+    }
+}

--- a/test/Config.Json.Test/Startup/appsettings.json
+++ b/test/Config.Json.Test/Startup/appsettings.json
@@ -1,0 +1,6 @@
+{
+  "RoomDefaultTemperature": "22",
+  "SpaceshipSetting": {
+    "AutoDestructTimeout": "300"
+  }
+}


### PR DESCRIPTION
Sometimes it was hard to keep in check all the mappings of a project with 50+ settings.
Added a generic method to parse the entire JSON file to a class - also added a unit test to test the workflow.
