### PR TITLE
Get instance with config section values

### DIFF
--- a/src/Config.Binder/ConfigurationBinder.cs
+++ b/src/Config.Binder/ConfigurationBinder.cs
@@ -174,6 +174,20 @@ namespace Microsoft.Extensions.Configuration
             }
             return defaultValue;
         }
+        
+        /// <summary>
+        /// Extracts the specified section and converts it to type T.
+        /// </summary>
+        /// <typeparam name="T">The type to convert the section to.</typeparam>
+        /// <param name="configuration">The configuration.</param>
+        /// <param name="section">The name of the configuration section to use.</param>
+        /// <returns>The converted value.</returns>
+        public static T GetInstance<T>(this IConfiguration configuration, string section) where T : class, new()
+        {
+            var instance = new T();
+            configuration.GetSection(section).Bind(instance);
+            return instance;
+        }
 
         private static void BindNonScalar(this IConfiguration configuration, object instance, BinderOptions options)
         {


### PR DESCRIPTION
The need for an easy way of reading configuration values to config classes would help as the GetValue<T> don't support that (only primitives).  Method wrapps the bind extension and reduces the need to instantiate the object before binding with the configuration.